### PR TITLE
Update authorize endpoint from v1 to v2

### DIFF
--- a/pkg/authz/check/handlers.go
+++ b/pkg/authz/check/handlers.go
@@ -11,7 +11,7 @@ func (svc CheckService) GetRoutes() []service.Route {
 	return []service.Route{
 		// Standard Authorization
 		{
-			Pattern: "/v1/authorize",
+			Pattern: "/v2/authorize",
 			Method:  "POST",
 			Handler: middleware.ChainMiddleware(
 				service.NewRouteHandler(svc.Env(), authorize),

--- a/tests/authz-wildcard.json
+++ b/tests/authz-wildcard.json
@@ -611,7 +611,7 @@
             "name": "checkUserAOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -642,7 +642,7 @@
             "name": "checkUserANotOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -673,7 +673,7 @@
             "name": "checkUserBNotOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -704,7 +704,7 @@
             "name": "checkUserBOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -735,7 +735,7 @@
             "name": "checkUserCOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -766,7 +766,7 @@
             "name": "checkUserCNotOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -797,7 +797,7 @@
             "name": "checkUserDNotOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -828,7 +828,7 @@
             "name": "checkUserDOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -859,7 +859,7 @@
             "name": "checkUserEOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -890,7 +890,7 @@
             "name": "checkUserENotOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -921,7 +921,7 @@
             "name": "checkUserFNotOwnerOfReportA",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -952,7 +952,7 @@
             "name": "checkUserFOwnerOfReportB",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -355,7 +355,7 @@
             "name": "checkAccessWithContextAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -386,7 +386,7 @@
             "name": "checkAccessWithContextNotAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -417,7 +417,7 @@
             "name": "checkAccessDirectWarrantAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -445,7 +445,7 @@
             "name": "checkAccessUsersetRuleAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -473,7 +473,7 @@
             "name": "checkAccessAllOfRuleAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [
@@ -501,7 +501,7 @@
             "name": "checkAccessNoneOfRuleAuthorized",
             "request": {
                 "method": "POST",
-                "url": "/v1/authorize",
+                "url": "/v2/authorize",
                 "body": {
                     "op": "anyOf",
                     "warrants": [


### PR DESCRIPTION
This PR updates the authorize endpoint to match the API endpoint available in Warrant Cloud so SDKs can continue to work as expected.