### PR TITLE
Allow custom auth middleware when initializing router

### DIFF
--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -253,6 +253,6 @@ func main() {
 	}
 
 	log.Debug().Msgf("Listening on port %d", config.Port)
-	shutdownErr := http.ListenAndServe(fmt.Sprintf(":%d", config.Port), service.NewRouter(&config, "", routes))
+	shutdownErr := http.ListenAndServe(fmt.Sprintf(":%d", config.Port), service.NewRouter(&config, "", routes, nil))
 	log.Fatal().Err(shutdownErr).Msg("")
 }

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -28,7 +28,9 @@ type AuthInfo struct {
 	TenantId string
 }
 
-func AuthMiddleware(next http.Handler, config *config.Config, enableSessionAuth bool) http.Handler {
+type AuthMiddlewareFunc func(next http.Handler, config *config.Config, enableSessionAuth bool) http.Handler
+
+func DefaultAuthMiddleware(next http.Handler, config *config.Config, enableSessionAuth bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 


### PR DESCRIPTION
This PR allows for a custom auth middleware to be used in place of the default auth middleware. When initializing the router, a function of type `AuthMiddlewareFunc` is accepted to replace the default middleware.