### PR TITLE
Remove update of unique key column from repository Create method of permission, role, feature, and pricing-tier resources

### DIFF
--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -34,7 +34,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 			) VALUES (?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				objectId = ?,
-				featureId = ?,
 				name = ?,
 				description = ?,
 				createdAt = CURRENT_TIMESTAMP(6),
@@ -45,7 +44,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetFeatureId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -37,7 +37,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?, ?, ?)
 			ON CONFLICT (feature_id) DO UPDATE SET
 				object_id = ?,
-				feature_id = ?,
 				name = ?,
 				description = ?,
 				created_at = CURRENT_TIMESTAMP(6),
@@ -49,7 +48,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetFeatureId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/permission/mysql.go
+++ b/pkg/authz/permission/mysql.go
@@ -34,7 +34,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 			) VALUES (?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				objectId = ?,
-				permissionId = ?,
 				name = ?,
 				description = ?,
 				createdAt = CURRENT_TIMESTAMP(6),
@@ -45,7 +44,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetPermissionId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -37,7 +37,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?, ?, ?)
 			ON CONFLICT (permission_id) DO UPDATE SET
 				object_id = ?,
-				permission_id = ?,
 				name = ?,
 				description = ?,
 				created_at = CURRENT_TIMESTAMP(6),
@@ -49,7 +48,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetPermissionId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -34,7 +34,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 			) VALUES (?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				objectId = ?,
-				pricingTierId = ?,
 				name = ?,
 				description = ?,
 				createdAt = CURRENT_TIMESTAMP(6),
@@ -45,7 +44,6 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetPricingTierId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -37,7 +37,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?, ?, ?)
 			ON CONFLICT (pricing_tier_id) DO UPDATE SET
 				object_id = ?,
-				pricing_tier_id = ?,
 				name = ?,
 				description = ?,
 				created_at = CURRENT_TIMESTAMP(6),
@@ -49,7 +48,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetPricingTierId(),
 		model.GetName(),
 		model.GetDescription(),
 	)

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -34,7 +34,6 @@ func (repo MySQLRepository) Create(ctx context.Context, role Model) (int64, erro
 			) VALUES (?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				objectId = ?,
-				roleId = ?,
 				name = ?,
 				description = ?,
 				createdAt = CURRENT_TIMESTAMP(6),
@@ -45,7 +44,6 @@ func (repo MySQLRepository) Create(ctx context.Context, role Model) (int64, erro
 		role.GetName(),
 		role.GetDescription(),
 		role.GetObjectId(),
-		role.GetRoleId(),
 		role.GetName(),
 		role.GetDescription(),
 	)

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -37,7 +37,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?, ?, ?)
 			ON CONFLICT (role_id) DO UPDATE SET
 				object_id = ?,
-				role_id = ?,
 				name = ?,
 				description = ?,
 				created_at = CURRENT_TIMESTAMP(6),
@@ -49,7 +48,6 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 		model.GetName(),
 		model.GetDescription(),
 		model.GetObjectId(),
-		model.GetRoleId(),
 		model.GetName(),
 		model.GetDescription(),
 	)


### PR DESCRIPTION
In every Warrant resource's repository `Create` method, we have an update clause that executes in the case of a duplicate record based on a matching unique key column (e.g. `featureId`, `permissionId`, etc). This means that a record for a resource of that type with the same unique key already exists but is deleted (i.e. `deletedAt` is not `NULL`). Currently, for the `permission`, `role`, `feature`, and `pricing-tier` resources, we also update the unique key column in the update clause. Although this doesn't have any functional impact, we don't need to do this, so this PR removes the unique key column from the update clause for each of those resources.