### PR TITLE
Generate event UUIDs in code rather than relying on the underlying eventstore database

### DIFF
--- a/pkg/event/mysql.go
+++ b/pkg/event/mysql.go
@@ -35,12 +35,14 @@ func (repo MySQLRepository) TrackResourceEvents(ctx context.Context, models []Re
 		ctx,
 		`
 		   INSERT INTO resourceEvent (
+			  id,
 			  type,
 			  source,
 			  resourceType,
 			  resourceId,
 			  meta
 		   ) VALUES (
+			  UUID_TO_BIN(:id),
 			  :type,
 			  :source,
 			  :resourceType,
@@ -159,6 +161,7 @@ func (repo MySQLRepository) TrackAccessEvents(ctx context.Context, models []Acce
 		ctx,
 		`
 		   INSERT INTO accessEvent (
+			  id,
 			  type,
 			  source,
 			  objectType,
@@ -170,6 +173,7 @@ func (repo MySQLRepository) TrackAccessEvents(ctx context.Context, models []Acce
 			  context,
 			  meta
 		   ) VALUES (
+			  UUID_TO_BIN(:id),
 			  :type,
 			  :source,
 			  :objectType,

--- a/pkg/event/postgres.go
+++ b/pkg/event/postgres.go
@@ -35,12 +35,14 @@ func (repo PostgresRepository) TrackResourceEvents(ctx context.Context, models [
 		ctx,
 		`
 		   INSERT INTO resource_event (
+			  id,
 			  type,
 			  source,
 			  resource_type,
 			  resource_id,
 			  meta
 		   ) VALUES (
+			  :id,
 			  :type,
 			  :source,
 			  :resource_type,
@@ -159,6 +161,7 @@ func (repo PostgresRepository) TrackAccessEvents(ctx context.Context, models []A
 		ctx,
 		`
 		   INSERT INTO access_event (
+			  id,
 			  type,
 			  source,
 			  object_type,
@@ -170,6 +173,7 @@ func (repo PostgresRepository) TrackAccessEvents(ctx context.Context, models []A
 			  context,
 			  meta
 		   ) VALUES (
+			  :id,
 			  :type,
 			  :source,
 			  :object_type,

--- a/pkg/event/spec.go
+++ b/pkg/event/spec.go
@@ -88,6 +88,7 @@ func (spec CreateAccessEventSpec) ToAccessEvent() (*AccessEvent, error) {
 	}
 
 	return &AccessEvent{
+		ID:              uuid.NewString(),
 		Type:            spec.Type,
 		Source:          spec.Source,
 		ObjectType:      spec.ObjectType,


### PR DESCRIPTION
For each resource event / access event, we generate a UUID. This UUID is typically generated by the underlying database when a new event record is inserted. Since each database has its own way of generating UUIDs (or lack of UUID support), it's better to generate a UUID in the code. This PR updates the events service to generate a UUID for each event before the event is persisted.