### PR TITLE
 modified the definition column to be marked as NOT NULL

### DIFF
--- a/migrations/datastore/mysql/000001_init.up.sql
+++ b/migrations/datastore/mysql/000001_init.up.sql
@@ -4,6 +4,7 @@ CREATE TABLE IF NOT EXISTS objectType (
   id int NOT NULL AUTO_INCREMENT,
   typeId varchar(64) NOT NULL,
   definition json DEFAULT NULL,
+  ALTER TABLE table_name MODIFY COLUMN definition JSON NOT NULL;
   createdAt timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
   updatedAt timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   deletedAt timestamp(6) NULL DEFAULT NULL,

--- a/migrations/datastore/postgres/000001_init.up.sql
+++ b/migrations/datastore/postgres/000001_init.up.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS object_type (
   id bigserial PRIMARY KEY,
   type_id varchar(64) NOT NULL CONSTRAINT object_type_uk_type_id UNIQUE,
   definition jsonb DEFAULT NULL,
+  ALTER TABLE table_name MODIFY COLUMN definition JSON NOT NULL;
   created_at timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
   updated_at timestamp(6) NULL DEFAULT CURRENT_TIMESTAMP(6),
   deleted_at timestamp(6) NULL DEFAULT NULL


### PR DESCRIPTION
 modified the column named "definition" in the table named "table_name", changes its data type to JSON and added the NOT NULL constraint to it. This means that any attempts to insert or update records in the table that do not provide a value for the "definition" column will result in a database error.