### PR TITLE
Add build tag for sqlite + stubbed sqlite db

### DIFF
--- a/cmd/warrant/Makefile
+++ b/cmd/warrant/Makefile
@@ -1,9 +1,8 @@
-NAME    = warrant
+NAME       = warrant
 BUILD_PATH = bin/$(NAME)
-GOENV   = GOARCH=amd64 GOOS=linux CGO_ENABLED=0
-GOCMD   = go
-GOBUILD = $(GOCMD) build -o
-VERSION = $(shell cat VERSION)
+GOENV      = GOARCH=amd64 GOOS=linux CGO_ENABLED=0
+GOCMD      = go
+GOBUILD    = $(GOCMD) build -v -o $(BUILD_PATH)
 
 .PHONY: clean
 clean:
@@ -12,9 +11,9 @@ clean:
 .PHONY: dev
 dev: clean
 	$(GOCMD) get
-	$(GOBUILD) $(BUILD_PATH) main.go
+	$(GOBUILD) -tags="sqlite" main.go
 
 .PHONY: build
 build: clean
 	$(GOCMD) get
-	$(GOENV) $(GOBUILD) $(BUILD_PATH) -ldflags="-s -w" main.go
+	$(GOENV) $(GOBUILD) -ldflags="-s -w" main.go

--- a/pkg/database/sqlite-stub.go
+++ b/pkg/database/sqlite-stub.go
@@ -1,0 +1,36 @@
+//go:build !sqlite
+// +build !sqlite
+
+package database
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/warrant-dev/warrant/pkg/config"
+)
+
+type SQLite struct {
+	SQL
+	Config config.SQLiteConfig
+}
+
+func NewSQLite(config config.SQLiteConfig) *SQLite {
+	return nil
+}
+
+func (ds SQLite) Type() string {
+	return TypeSQLite
+}
+
+func (ds *SQLite) Connect(ctx context.Context) error {
+	return fmt.Errorf("sqlite not supported")
+}
+
+func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
+	return fmt.Errorf("sqlite not supported")
+}
+
+func (ds SQLite) Ping(ctx context.Context) error {
+	return fmt.Errorf("sqlite not supported")
+}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -1,3 +1,6 @@
+//go:build sqlite
+// +build sqlite
+
 package database
 
 import (


### PR DESCRIPTION
The `go-sqlite3` lib requires CGO which we don't have enabled and will require proper cross-compiling to get working, and likely a different docker base image. For now, given we don't anticipate sqlite usage in prod, don't compile it via a build tag. You can still build with sqlite locally with `make dev` and run all apirunner tests.

In the future we can consider replacing with a pure-Go sqlite impl.