### PR TITLE
Feat/update mysql connect logic

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,10 +89,10 @@ func NewConfig() Config {
 	viper.SetDefault("levelLevel", zerolog.DebugLevel)
 	viper.SetDefault("enableAccessLog", true)
 	viper.SetDefault("datastore.mysql.migrationSource", DefaultMySQLDatastoreMigrationSource)
-	viper.SetDefault("eventstore.mysql.migrationSource", DefaultMySQLEventstoreMigrationSource)
 	viper.SetDefault("datastore.postgres.migrationSource", DefaultPostgresDatastoreMigrationSource)
-	viper.SetDefault("eventstore.postgres.migrationSource", DefaultPostgresEventstoreMigrationSource)
 	viper.SetDefault("datastore.sqlite.migrationSource", DefaultSQLiteDatastoreMigrationSource)
+	viper.SetDefault("eventstore.mysql.migrationSource", DefaultMySQLEventstoreMigrationSource)
+	viper.SetDefault("eventstore.postgres.migrationSource", DefaultPostgresEventstoreMigrationSource)
 	viper.SetDefault("eventstore.sqlite.migrationSource", DefaultSQLiteEventstoreMigrationSource)
 	viper.SetDefault("authentication.userIdClaim", DefaultAuthenticationUserIdClaim)
 

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -40,6 +40,7 @@ func (ds *Postgres) Connect(ctx context.Context) error {
 	var db *sqlx.DB
 	var err error
 
+	// open new database connection without specifying the database name
 	usernamePassword := url.UserPassword(ds.Config.Username, ds.Config.Password).String()
 	db, err = sqlx.Open("postgres", fmt.Sprintf("postgres://%s@%s/?sslmode=%s", usernamePassword, ds.Config.Hostname, ds.Config.SSLMode))
 	if err != nil {
@@ -56,6 +57,8 @@ func (ds *Postgres) Connect(ctx context.Context) error {
 	}
 
 	db.Close()
+
+	// open new database connection, this time specifying the database name
 	db, err = sqlx.Open("postgres", fmt.Sprintf("postgres://%s@%s/%s?sslmode=%s", usernamePassword, ds.Config.Hostname, ds.Config.Database, ds.Config.SSLMode))
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("Unable to establish connection to postgres database %s. Shutting down server.", ds.Config.Database))


### PR DESCRIPTION
Currently the connection logic for MySQL is the following:
1. Open a connection to MySQL without a database name specified.
2. Create the specified database if it does not already exist.
3. Execute a `USE <database_name>` statement to switch the current connection's database to the specified database.

Since `sql.DB` is a connection pool and not a reference to an individual connection, this approach can have problems when using multiple databases within the same MySQL server. This PR updates the connection logic to the following:
1. Open a connection to MySQL without a database name specified.
2. Create the specified database if it does not already exist.
3. Close the connection.
4. Open a connection to MySQL with the database name specified.

This approach avoids the pitfall mentioned above.