### PR TITLE
Allow events to be configured to run synchronously and add initial test suite for events

### DIFF
--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -182,7 +182,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Could not initialize EventRepository")
 	}
 
-	eventSvc := event.NewService(svcEnv, eventRepository)
+	eventSvc := event.NewService(svcEnv, eventRepository, config.Eventstore.SynchronizeEvents)
 
 	// Init object type repo and service
 	objectTypeRepository, err := objecttype.NewRepository(svcEnv.DB())

--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -369,11 +369,19 @@ func (svc CheckService) Check(ctx context.Context, authInfo *service.AuthInfo, w
 	}
 
 	if match {
-		svc.eventSvc.TrackAccessAllowedEvent(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, warrantCheck.Subject.ObjectType, warrantCheck.Subject.ObjectId, warrantCheck.Subject.Relation, warrantCheck.Context)
+		err := svc.eventSvc.TrackAccessAllowedEvent(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, warrantCheck.Subject.ObjectType, warrantCheck.Subject.ObjectId, warrantCheck.Subject.Relation, warrantCheck.Context)
+		if err != nil {
+			return false, decisionPath, err
+		}
+
 		return true, decisionPath, nil
 	}
 
-	svc.eventSvc.TrackAccessDeniedEvent(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, warrantCheck.Subject.ObjectType, warrantCheck.Subject.ObjectId, warrantCheck.Subject.Relation, warrantCheck.Context)
+	err = svc.eventSvc.TrackAccessDeniedEvent(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, warrantCheck.Subject.ObjectType, warrantCheck.Subject.ObjectId, warrantCheck.Subject.Relation, warrantCheck.Context)
+	if err != nil {
+		return false, decisionPath, err
+	}
+
 	return false, decisionPath, nil
 }
 

--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -51,7 +51,11 @@ func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -104,7 +108,11 @@ func (svc FeatureService) UpdateByFeatureId(ctx context.Context, featureId strin
 	}
 
 	updatedFeatureSpec := updatedFeature.ToFeatureSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeFeature, updatedFeature.GetFeatureId(), updatedFeatureSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeFeature, updatedFeature.GetFeatureId(), updatedFeatureSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedFeatureSpec, nil
 }
 
@@ -120,7 +128,11 @@ func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId strin
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeFeature, featureId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeFeature, featureId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/objecttype/service.go
+++ b/pkg/authz/objecttype/service.go
@@ -50,7 +50,11 @@ func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTy
 		return nil, err
 	}
 
-	svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeObjectType, newObjectType.GetTypeId(), newObjectTypeSpec)
+	err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeObjectType, newObjectType.GetTypeId(), newObjectTypeSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return newObjectTypeSpec, nil
 }
 
@@ -119,7 +123,11 @@ func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, 
 		return nil, err
 	}
 
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeObjectType, typeId, updatedObjectTypeSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeObjectType, typeId, updatedObjectTypeSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedObjectTypeSpec, nil
 }
 
@@ -134,6 +142,10 @@ func (svc ObjectTypeService) DeleteByTypeId(ctx context.Context, typeId string) 
 		return err
 	}
 
-	svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeObjectType, typeId, nil)
+	err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeObjectType, typeId, nil)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -51,7 +51,11 @@ func (svc PermissionService) Create(ctx context.Context, permissionSpec Permissi
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -119,7 +123,11 @@ func (svc PermissionService) UpdateByPermissionId(ctx context.Context, permissio
 	}
 
 	updatedPermissionSpec := updatedPermission.ToPermissionSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePermission, updatedPermission.GetPermissionId(), updatedPermissionSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePermission, updatedPermission.GetPermissionId(), updatedPermissionSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedPermissionSpec, nil
 }
 
@@ -140,7 +148,11 @@ func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissio
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(txCtx, ResourceTypePermission, permissionId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -51,7 +51,11 @@ func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec Pricin
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -119,7 +123,11 @@ func (svc PricingTierService) UpdateByPricingTierId(ctx context.Context, pricing
 	}
 
 	updatedPricingTierSpec := updatedPricingTier.ToPricingTierSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePricingTier, updatedPricingTier.GetPricingTierId(), updatedPricingTierSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePricingTier, updatedPricingTier.GetPricingTierId(), updatedPricingTierSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedPricingTierSpec, nil
 }
 
@@ -140,7 +148,11 @@ func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricing
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/role/service.go
+++ b/pkg/authz/role/service.go
@@ -51,7 +51,11 @@ func (svc RoleService) Create(ctx context.Context, roleSpec RoleSpec) (*RoleSpec
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -119,7 +123,11 @@ func (svc RoleService) UpdateByRoleId(ctx context.Context, roleId string, roleSp
 	}
 
 	updatedRoleSpec := updatedRole.ToRoleSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeRole, updatedRole.GetRoleId(), updatedRoleSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeRole, updatedRole.GetRoleId(), updatedRoleSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedRoleSpec, nil
 }
 
@@ -140,7 +148,11 @@ func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) error 
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(txCtx, ResourceTypeRole, roleId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeRole, roleId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/tenant/service.go
+++ b/pkg/authz/tenant/service.go
@@ -63,7 +63,11 @@ func (svc TenantService) Create(ctx context.Context, tenantSpec TenantSpec) (*Te
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -130,7 +134,11 @@ func (svc TenantService) UpdateByTenantId(ctx context.Context, tenantId string, 
 	}
 
 	updatedTenantSpec := updatedTenant.ToTenantSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeTenant, updatedTenant.GetTenantId(), updatedTenantSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeTenant, updatedTenant.GetTenantId(), updatedTenantSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedTenantSpec, nil
 }
 
@@ -151,7 +159,11 @@ func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) 
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeTenant, tenantId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeTenant, tenantId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -63,7 +63,11 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 			return err
 		}
 
-		svc.eventSvc.TrackResourceCreated(txCtx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
+		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 
@@ -125,7 +129,11 @@ func (svc UserService) UpdateByUserId(ctx context.Context, userId string, userSp
 	}
 
 	updatedUserSpec := updatedUser.ToUserSpec()
-	svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeUser, updatedUser.GetUserId(), updatedUserSpec)
+	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeUser, updatedUser.GetUserId(), updatedUserSpec)
+	if err != nil {
+		return nil, err
+	}
+
 	return updatedUserSpec, nil
 }
 
@@ -146,7 +154,11 @@ func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error 
 			return err
 		}
 
-		svc.eventSvc.TrackResourceDeleted(txCtx, ResourceTypeUser, userId, nil)
+		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeUser, userId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -74,7 +74,11 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 			}
 		}
 
-		svc.eventSvc.TrackAccessGrantedEvent(txCtx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
+		err = svc.eventSvc.TrackAccessGrantedEvent(ctx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 	if err != nil {
@@ -153,7 +157,11 @@ func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) e
 			return err
 		}
 
-		svc.eventSvc.TrackAccessRevokedEvent(txCtx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
+		err = svc.eventSvc.TrackAccessRevokedEvent(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,9 +71,10 @@ type SQLiteConfig struct {
 }
 
 type EventstoreConfig struct {
-	MySQL    *MySQLConfig    `mapstructure:"mysql"`
-	Postgres *PostgresConfig `mapstructure:"postgres"`
-	SQLite   *SQLiteConfig   `mapstructure:"sqlite"`
+	MySQL             *MySQLConfig    `mapstructure:"mysql"`
+	Postgres          *PostgresConfig `mapstructure:"postgres"`
+	SQLite            *SQLiteConfig   `mapstructure:"sqlite"`
+	SynchronizeEvents bool            `mapstructure:"synchronizeEvents"`
 }
 
 type AuthConfig struct {
@@ -94,6 +95,7 @@ func NewConfig() Config {
 	viper.SetDefault("eventstore.mysql.migrationSource", DefaultMySQLEventstoreMigrationSource)
 	viper.SetDefault("eventstore.postgres.migrationSource", DefaultPostgresEventstoreMigrationSource)
 	viper.SetDefault("eventstore.sqlite.migrationSource", DefaultSQLiteEventstoreMigrationSource)
+	viper.SetDefault("eventstore.synchronizeEvents", false)
 	viper.SetDefault("authentication.userIdClaim", DefaultAuthenticationUserIdClaim)
 
 	// If config file exists, use it

--- a/pkg/event/mysql.go
+++ b/pkg/event/mysql.go
@@ -127,6 +127,10 @@ func (repo MySQLRepository) ListResourceEvents(ctx context.Context, listParams L
 		}
 	}
 
+	for i := range resourceEvents {
+		models = append(models, &resourceEvents[i])
+	}
+
 	if len(resourceEvents) == 0 || len(resourceEvents) < int(listParams.Limit) {
 		return models, "", nil
 	}
@@ -138,10 +142,6 @@ func (repo MySQLRepository) ListResourceEvents(ctx context.Context, listParams L
 	})
 	if err != nil {
 		return models, "", err
-	}
-
-	for i := range resourceEvents {
-		models = append(models, &resourceEvents[i])
 	}
 
 	return models, lastIdStr, nil
@@ -283,6 +283,10 @@ func (repo MySQLRepository) ListAccessEvents(ctx context.Context, listParams Lis
 		}
 	}
 
+	for i := range accessEvents {
+		models = append(models, &accessEvents[i])
+	}
+
 	if len(accessEvents) == 0 || len(accessEvents) < int(listParams.Limit) {
 		return models, "", nil
 	}
@@ -294,10 +298,6 @@ func (repo MySQLRepository) ListAccessEvents(ctx context.Context, listParams Lis
 	})
 	if err != nil {
 		return models, "", err
-	}
-
-	for i := range accessEvents {
-		models = append(models, &accessEvents[i])
 	}
 
 	return models, lastIdStr, nil

--- a/pkg/event/postgres.go
+++ b/pkg/event/postgres.go
@@ -127,6 +127,10 @@ func (repo PostgresRepository) ListResourceEvents(ctx context.Context, listParam
 		}
 	}
 
+	for i := range resourceEvents {
+		models = append(models, &resourceEvents[i])
+	}
+
 	if len(resourceEvents) == 0 || len(resourceEvents) < int(listParams.Limit) {
 		return models, "", nil
 	}
@@ -138,10 +142,6 @@ func (repo PostgresRepository) ListResourceEvents(ctx context.Context, listParam
 	})
 	if err != nil {
 		return models, "", err
-	}
-
-	for i := range resourceEvents {
-		models = append(models, &resourceEvents[i])
 	}
 
 	return models, lastIdStr, nil
@@ -283,6 +283,10 @@ func (repo PostgresRepository) ListAccessEvents(ctx context.Context, listParams 
 		}
 	}
 
+	for i := range accessEvents {
+		models = append(models, &accessEvents[i])
+	}
+
 	if len(accessEvents) == 0 || len(accessEvents) < int(listParams.Limit) {
 		return models, "", nil
 	}
@@ -294,10 +298,6 @@ func (repo PostgresRepository) ListAccessEvents(ctx context.Context, listParams 
 	})
 	if err != nil {
 		return models, "", err
-	}
-
-	for i := range accessEvents {
-		models = append(models, &accessEvents[i])
 	}
 
 	return models, lastIdStr, nil

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -1,0 +1,700 @@
+{
+    "ignoredFields": [
+        "createdAt",
+        "id"
+    ],
+    "tests": [
+        {
+            "name": "listLastThreeResourceEvents",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        },
+                        {
+                            "type": "role.deleted",
+                            "source": "api",
+                            "resourceType": "role",
+                            "resourceId": "senior-accountant"
+                        },
+                        {
+                            "type": "permission.deleted",
+                            "source": "api",
+                            "resourceType": "permission",
+                            "resourceId": "view-balance-sheet"
+                        }
+                    ],
+                    "lastId": "{{ listLastThreeResourceEvents.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listNextTwoResourceEvents",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=2&lastId={{ listLastThreeResourceEvents.lastId }}"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "permission.deleted",
+                            "source": "api",
+                            "resourceType": "permission",
+                            "resourceId": "edit-balance-sheet"
+                        },
+                        {
+                            "type": "permission.created",
+                            "source": "api",
+                            "resourceType": "permission",
+                            "resourceId": "edit-balance-sheet",
+                            "meta": {
+                                "description": "Grants access to edit the balance sheet.",
+                                "name": "Edit Balance Sheet",
+                                "permissionId": "edit-balance-sheet"
+                            }
+                        }
+                    ],
+                    "lastId": "{{ listNextTwoResourceEvents.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listResourceEventsFilterBySource",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=5&source=ui"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": []
+                }
+            }
+        },
+        {
+            "name": "listResourceEventsFilterByType",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=5&type=user.deleted"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-5"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-4"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-3"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-2"
+                        }
+                    ],
+                    "lastId": "{{ listResourceEventsFilterByType.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listResourceEventsFilterByResourceType",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=5&resourceType=user"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        },
+                        {
+                            "type": "user.created",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev",
+                                "userId": "user-a"
+                            }
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-5"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-4"
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-3"
+                        }
+                    ],
+                    "lastId": "{{ listResourceEventsFilterByResourceType.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listResourceEventsFilterByResourceTypeAndResourceId",
+            "request": {
+                "method": "GET",
+                "url": "/v1/resource-events?limit=5&resourceType=user&resourceId=user-a"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        },
+                        {
+                            "type": "user.created",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev",
+                                "userId": "user-a"
+                            }
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        },
+                        {
+                            "type": "user.created",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev",
+                                "userId": "user-a"
+                            }
+                        },
+                        {
+                            "type": "user.deleted",
+                            "source": "api",
+                            "resourceType": "user",
+                            "resourceId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listResourceEventsFilterByResourceTypeAndResourceId.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listLastThreeAccessEvents",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "permission.access_revoked",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "role",
+                            "subjectId": "senior-accountant"
+                        },
+                        {
+                            "type": "permission.access_revoked",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "role.access_revoked",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "senior-accountant",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listLastThreeAccessEvents.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listNextTwoAccessEvents",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=2&lastId={{ listLastThreeAccessEvents.lastId }}"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "role.access_granted",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "senior-accountant",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listNextTwoAccessEvents.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterBySource",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=5&source=ui"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": []
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterByType",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=4&type=permission.access_granted"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "role",
+                            "subjectId": "senior-accountant"
+                        },
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "role",
+                            "subjectId": "senior-accountant"
+                        },
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "role",
+                            "subjectId": "senior-accountant"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterByType.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterByObjectType",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=5&objectType=report"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "non-owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor-viewer",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "viewer",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterByObjectType.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterByObjectTypeAndObjectId",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=5&objectType=report&objectId=report-a"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "non-owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor-viewer",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "viewer",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterByObjectTypeAndObjectId.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterByObjectTypeAndObjectIdAndRelation",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=5&objectType=report&objectId=report-a&relation=owner"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-f"
+                        },
+                        {
+                            "type": "report.access_allowed",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-e"
+                        },
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-d"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterByObjectTypeAndObjectIdAndRelation.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterBySubjectType",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=5&subjectType=user"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "permission.access_revoked",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "role.access_revoked",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "senior-accountant",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "role.access_granted",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "senior-accountant",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "permission.access_granted",
+                            "source": "api",
+                            "objectType": "permission",
+                            "objectId": "edit-balance-sheet",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterBySubjectType.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterBySubjectTypeAndSubjectId",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=2&subjectType=user&subjectId=user-c"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "role.access_revoked",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "admin-a",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-c"
+                        },
+                        {
+                            "type": "report.access_denied",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-b",
+                            "relation": "owner",
+                            "subjectType": "user",
+                            "subjectId": "user-c"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterBySubjectTypeAndSubjectId.lastId }}"
+                }
+            }
+        },
+        {
+            "name": "listAccessEventsFilterBySubjectTypeAndSubjectRelation",
+            "request": {
+                "method": "GET",
+                "url": "/v1/access-events?limit=4&subjectType=role&subjectRelation=member"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "events": [
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "*",
+                            "relation": "owner",
+                            "subjectType": "role",
+                            "subjectId": "admin-a",
+                            "subjectRelation": "member"
+                        },
+                        {
+                            "type": "report.access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "*",
+                            "relation": "owner",
+                            "subjectType": "role",
+                            "subjectId": "admin-b",
+                            "subjectRelation": "member"
+                        },
+                        {
+                            "type": "report.access_granted",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "*",
+                            "relation": "owner",
+                            "subjectType": "role",
+                            "subjectId": "admin-b",
+                            "subjectRelation": "member"
+                        },
+                        {
+                            "type": "report.access_granted",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "*",
+                            "relation": "owner",
+                            "subjectType": "role",
+                            "subjectId": "admin-a",
+                            "subjectRelation": "member"
+                        }
+                    ],
+                    "lastId": "{{ listAccessEventsFilterBySubjectTypeAndSubjectRelation.lastId }}"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Events can now be configured to run synchronously. A `synchronizeEvents` boolean can now be passed as part of the `eventstore` config to specify that events be run synchronously.
```yaml
eventstore:
  synchronizeEvents: true
```
Or via env var:
```bash
EVENTSTORE_SYNCHRONIZEEVENTS=true
```