### PR TITLE
Export service fields

### DIFF
--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -14,44 +14,44 @@ const ResourceTypeFeature = "feature"
 
 type FeatureService struct {
 	service.BaseService
-	repo      FeatureRepository
-	eventSvc  event.EventService
-	objectSvc object.ObjectService
+	Repository FeatureRepository
+	EventSvc   event.EventService
+	ObjectSvc  object.ObjectService
 }
 
-func NewService(env service.Env, repo FeatureRepository, eventSvc event.EventService, objectSvc object.ObjectService) FeatureService {
+func NewService(env service.Env, repository FeatureRepository, eventSvc event.EventService, objectSvc object.ObjectService) FeatureService {
 	return FeatureService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
-		objectSvc:   objectSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
+		ObjectSvc:   objectSvc,
 	}
 }
 
 func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (*FeatureSpec, error) {
 	var newFeature Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.objectSvc.Create(txCtx, *featureSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *featureSpec.ToObjectSpec())
 		if err != nil {
 			return err
 		}
 
-		_, err = svc.repo.GetByFeatureId(txCtx, featureSpec.FeatureId)
+		_, err = svc.Repository.GetByFeatureId(txCtx, featureSpec.FeatureId)
 		if err == nil {
 			return service.NewDuplicateRecordError("Feature", featureSpec.FeatureId, "A feature with the given featureId already exists")
 		}
 
-		newFeatureId, err := svc.repo.Create(txCtx, featureSpec.ToFeature(createdObject.ID))
+		newFeatureId, err := svc.Repository.Create(txCtx, featureSpec.ToFeature(createdObject.ID))
 		if err != nil {
 			return err
 		}
 
-		newFeature, err = svc.repo.GetById(txCtx, newFeatureId)
+		newFeature, err = svc.Repository.GetById(txCtx, newFeatureId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (
 }
 
 func (svc FeatureService) GetByFeatureId(ctx context.Context, featureId string) (*FeatureSpec, error) {
-	feature, err := svc.repo.GetByFeatureId(ctx, featureId)
+	feature, err := svc.Repository.GetByFeatureId(ctx, featureId)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func (svc FeatureService) GetByFeatureId(ctx context.Context, featureId string) 
 
 func (svc FeatureService) List(ctx context.Context, listParams middleware.ListParams) ([]FeatureSpec, error) {
 	featureSpecs := make([]FeatureSpec, 0)
-	features, err := svc.repo.List(ctx, listParams)
+	features, err := svc.Repository.List(ctx, listParams)
 	if err != nil {
 		return featureSpecs, nil
 	}
@@ -90,25 +90,25 @@ func (svc FeatureService) List(ctx context.Context, listParams middleware.ListPa
 }
 
 func (svc FeatureService) UpdateByFeatureId(ctx context.Context, featureId string, featureSpec UpdateFeatureSpec) (*FeatureSpec, error) {
-	currentFeature, err := svc.repo.GetByFeatureId(ctx, featureId)
+	currentFeature, err := svc.Repository.GetByFeatureId(ctx, featureId)
 	if err != nil {
 		return nil, err
 	}
 
 	currentFeature.SetName(featureSpec.Name)
 	currentFeature.SetDescription(featureSpec.Description)
-	err = svc.repo.UpdateByFeatureId(ctx, featureId, currentFeature)
+	err = svc.Repository.UpdateByFeatureId(ctx, featureId, currentFeature)
 	if err != nil {
 		return nil, err
 	}
 
-	updatedFeature, err := svc.repo.GetByFeatureId(ctx, featureId)
+	updatedFeature, err := svc.Repository.GetByFeatureId(ctx, featureId)
 	if err != nil {
 		return nil, err
 	}
 
 	updatedFeatureSpec := updatedFeature.ToFeatureSpec()
-	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeFeature, updatedFeature.GetFeatureId(), updatedFeatureSpec)
+	err = svc.EventSvc.TrackResourceUpdated(ctx, ResourceTypeFeature, updatedFeature.GetFeatureId(), updatedFeatureSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -118,17 +118,17 @@ func (svc FeatureService) UpdateByFeatureId(ctx context.Context, featureId strin
 
 func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.repo.DeleteByFeatureId(txCtx, featureId)
+		err := svc.Repository.DeleteByFeatureId(txCtx, featureId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.objectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeFeature, featureId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeFeature, featureId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeFeature, featureId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeFeature, featureId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/object/handlers.go
+++ b/pkg/authz/object/handlers.go
@@ -79,7 +79,7 @@ func ListHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) erro
 func GetHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
 	objectType := mux.Vars(r)["objectType"]
 	objectIdParam := mux.Vars(r)["objectId"]
-	object, err := svc.GetByObjectId(r.Context(), objectType, objectIdParam)
+	object, err := svc.GetByObjectTypeAndId(r.Context(), objectType, objectIdParam)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -12,32 +12,32 @@ import (
 
 type ObjectService struct {
 	service.BaseService
-	repo       ObjectRepository
-	eventSvc   event.EventService
-	warrantSvc warrant.WarrantService
+	Repository ObjectRepository
+	EventSvc   event.EventService
+	WarrantSvc warrant.WarrantService
 }
 
-func NewService(env service.Env, repo ObjectRepository, eventSvc event.EventService, warrantSvc warrant.WarrantService) ObjectService {
+func NewService(env service.Env, repository ObjectRepository, eventSvc event.EventService, warrantSvc warrant.WarrantService) ObjectService {
 	return ObjectService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
-		warrantSvc:  warrantSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
+		WarrantSvc:  warrantSvc,
 	}
 }
 
 func (svc ObjectService) Create(ctx context.Context, objectSpec ObjectSpec) (*ObjectSpec, error) {
-	_, err := svc.repo.GetByObjectTypeAndId(ctx, objectSpec.ObjectType, objectSpec.ObjectId)
+	_, err := svc.Repository.GetByObjectTypeAndId(ctx, objectSpec.ObjectType, objectSpec.ObjectId)
 	if err == nil {
 		return nil, service.NewDuplicateRecordError("Object", fmt.Sprintf("%s:%s", objectSpec.ObjectType, objectSpec.ObjectId), "An object with the given objectType and objectId already exists")
 	}
 
-	newObjectId, err := svc.repo.Create(ctx, *objectSpec.ToObject())
+	newObjectId, err := svc.Repository.Create(ctx, *objectSpec.ToObject())
 	if err != nil {
 		return nil, err
 	}
 
-	newObject, err := svc.repo.GetById(ctx, newObjectId)
+	newObject, err := svc.Repository.GetById(ctx, newObjectId)
 	if err != nil {
 		return nil, err
 	}
@@ -47,12 +47,12 @@ func (svc ObjectService) Create(ctx context.Context, objectSpec ObjectSpec) (*Ob
 
 func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.repo.DeleteByObjectTypeAndId(txCtx, objectType, objectId)
+		err := svc.Repository.DeleteByObjectTypeAndId(txCtx, objectType, objectId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.warrantSvc.DeleteRelatedWarrants(txCtx, objectType, objectId)
+		err = svc.WarrantSvc.DeleteRelatedWarrants(txCtx, objectType, objectId)
 		if err != nil {
 			return err
 		}
@@ -64,7 +64,7 @@ func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType
 }
 
 func (svc ObjectService) GetByObjectId(ctx context.Context, objectType string, objectId string) (*ObjectSpec, error) {
-	object, err := svc.repo.GetByObjectTypeAndId(ctx, objectType, objectId)
+	object, err := svc.Repository.GetByObjectTypeAndId(ctx, objectType, objectId)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (svc ObjectService) GetByObjectId(ctx context.Context, objectType string, o
 
 func (svc ObjectService) List(ctx context.Context, filterOptions *FilterOptions, listParams middleware.ListParams) ([]ObjectSpec, error) {
 	objectSpecs := make([]ObjectSpec, 0)
-	objects, err := svc.repo.List(ctx, filterOptions, listParams)
+	objects, err := svc.Repository.List(ctx, filterOptions, listParams)
 	if err != nil {
 		return objectSpecs, err
 	}

--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -63,7 +63,7 @@ func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType
 	return err
 }
 
-func (svc ObjectService) GetByObjectId(ctx context.Context, objectType string, objectId string) (*ObjectSpec, error) {
+func (svc ObjectService) GetByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (*ObjectSpec, error) {
 	object, err := svc.Repository.GetByObjectTypeAndId(ctx, objectType, objectId)
 	if err != nil {
 		return nil, err

--- a/pkg/authz/objecttype/service.go
+++ b/pkg/authz/objecttype/service.go
@@ -12,20 +12,20 @@ const ResourceTypeObjectType = "object-type"
 
 type ObjectTypeService struct {
 	service.BaseService
-	repo     ObjectTypeRepository
-	eventSvc event.EventService
+	Repository ObjectTypeRepository
+	EventSvc   event.EventService
 }
 
-func NewService(env service.Env, repo ObjectTypeRepository, eventSvc event.EventService) ObjectTypeService {
+func NewService(env service.Env, repository ObjectTypeRepository, eventSvc event.EventService) ObjectTypeService {
 	return ObjectTypeService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
 	}
 }
 
 func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error) {
-	_, err := svc.repo.GetByTypeId(ctx, objectTypeSpec.Type)
+	_, err := svc.Repository.GetByTypeId(ctx, objectTypeSpec.Type)
 	if err == nil {
 		return nil, service.NewDuplicateRecordError("ObjectType", objectTypeSpec.Type, "An objectType with the given type already exists")
 	}
@@ -35,12 +35,12 @@ func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTy
 		return nil, err
 	}
 
-	newObjectTypeId, err := svc.repo.Create(ctx, objectType)
+	newObjectTypeId, err := svc.Repository.Create(ctx, objectType)
 	if err != nil {
 		return nil, err
 	}
 
-	newObjectType, err := svc.repo.GetById(ctx, newObjectTypeId)
+	newObjectType, err := svc.Repository.GetById(ctx, newObjectTypeId)
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTy
 		return nil, err
 	}
 
-	err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeObjectType, newObjectType.GetTypeId(), newObjectTypeSpec)
+	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeObjectType, newObjectType.GetTypeId(), newObjectTypeSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTy
 }
 
 func (svc ObjectTypeService) GetByTypeId(ctx context.Context, typeId string) (*ObjectTypeSpec, error) {
-	objectType, err := svc.repo.GetByTypeId(ctx, typeId)
+	objectType, err := svc.Repository.GetByTypeId(ctx, typeId)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (svc ObjectTypeService) GetByTypeId(ctx context.Context, typeId string) (*O
 }
 
 func (svc ObjectTypeService) List(ctx context.Context, listParams middleware.ListParams) ([]ObjectTypeSpec, error) {
-	objectTypes, err := svc.repo.List(ctx, listParams)
+	objectTypes, err := svc.Repository.List(ctx, listParams)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +87,7 @@ func (svc ObjectTypeService) List(ctx context.Context, listParams middleware.Lis
 }
 
 func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error) {
-	currentObjectType, err := svc.repo.GetByTypeId(ctx, typeId)
+	currentObjectType, err := svc.Repository.GetByTypeId(ctx, typeId)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, 
 	}
 
 	currentObjectType.SetDefinition(updateTo.Definition)
-	err = svc.repo.UpdateByTypeId(ctx, typeId, currentObjectType)
+	err = svc.Repository.UpdateByTypeId(ctx, typeId, currentObjectType)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +108,7 @@ func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, 
 		return nil, err
 	}
 
-	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeObjectType, typeId, updatedObjectTypeSpec)
+	err = svc.EventSvc.TrackResourceUpdated(ctx, ResourceTypeObjectType, typeId, updatedObjectTypeSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -117,12 +117,12 @@ func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, 
 }
 
 func (svc ObjectTypeService) DeleteByTypeId(ctx context.Context, typeId string) error {
-	err := svc.repo.DeleteByTypeId(ctx, typeId)
+	err := svc.Repository.DeleteByTypeId(ctx, typeId)
 	if err != nil {
 		return err
 	}
 
-	err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeObjectType, typeId, nil)
+	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeObjectType, typeId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -14,44 +14,44 @@ const ResourceTypePermission = "permission"
 
 type PermissionService struct {
 	service.BaseService
-	repo      PermissionRepository
-	eventSvc  event.EventService
-	objectSvc object.ObjectService
+	Repository PermissionRepository
+	EventSvc   event.EventService
+	ObjectSvc  object.ObjectService
 }
 
-func NewService(env service.Env, repo PermissionRepository, eventSvc event.EventService, objectSvc object.ObjectService) PermissionService {
+func NewService(env service.Env, repository PermissionRepository, eventSvc event.EventService, objectSvc object.ObjectService) PermissionService {
 	return PermissionService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
-		objectSvc:   objectSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
+		ObjectSvc:   objectSvc,
 	}
 }
 
 func (svc PermissionService) Create(ctx context.Context, permissionSpec PermissionSpec) (*PermissionSpec, error) {
 	var newPermission Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.objectSvc.Create(txCtx, *permissionSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *permissionSpec.ToObjectSpec())
 		if err != nil {
 			return err
 		}
 
-		_, err = svc.repo.GetByPermissionId(txCtx, permissionSpec.PermissionId)
+		_, err = svc.Repository.GetByPermissionId(txCtx, permissionSpec.PermissionId)
 		if err == nil {
 			return service.NewDuplicateRecordError("Permission", permissionSpec.PermissionId, "A permission with the given permissionId already exists")
 		}
 
-		newPermissionId, err := svc.repo.Create(txCtx, permissionSpec.ToPermission(createdObject.ID))
+		newPermissionId, err := svc.Repository.Create(txCtx, permissionSpec.ToPermission(createdObject.ID))
 		if err != nil {
 			return err
 		}
 
-		newPermission, err = svc.repo.GetById(txCtx, newPermissionId)
+		newPermission, err = svc.Repository.GetById(txCtx, newPermissionId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func (svc PermissionService) Create(ctx context.Context, permissionSpec Permissi
 }
 
 func (svc PermissionService) GetByPermissionId(ctx context.Context, permissionId string) (*PermissionSpec, error) {
-	permission, err := svc.repo.GetByPermissionId(ctx, permissionId)
+	permission, err := svc.Repository.GetByPermissionId(ctx, permissionId)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (svc PermissionService) GetByPermissionId(ctx context.Context, permissionId
 func (svc PermissionService) List(ctx context.Context, listParams middleware.ListParams) ([]PermissionSpec, error) {
 	permissionSpecs := make([]PermissionSpec, 0)
 
-	permissions, err := svc.repo.List(ctx, listParams)
+	permissions, err := svc.Repository.List(ctx, listParams)
 	if err != nil {
 		return permissionSpecs, nil
 	}
@@ -91,25 +91,25 @@ func (svc PermissionService) List(ctx context.Context, listParams middleware.Lis
 }
 
 func (svc PermissionService) UpdateByPermissionId(ctx context.Context, permissionId string, permissionSpec UpdatePermissionSpec) (*PermissionSpec, error) {
-	currentPermission, err := svc.repo.GetByPermissionId(ctx, permissionId)
+	currentPermission, err := svc.Repository.GetByPermissionId(ctx, permissionId)
 	if err != nil {
 		return nil, err
 	}
 
 	currentPermission.SetName(permissionSpec.Name)
 	currentPermission.SetDescription(permissionSpec.Description)
-	err = svc.repo.UpdateByPermissionId(ctx, permissionId, currentPermission)
+	err = svc.Repository.UpdateByPermissionId(ctx, permissionId, currentPermission)
 	if err != nil {
 		return nil, err
 	}
 
-	updatedPermission, err := svc.repo.GetByPermissionId(ctx, permissionId)
+	updatedPermission, err := svc.Repository.GetByPermissionId(ctx, permissionId)
 	if err != nil {
 		return nil, err
 	}
 
 	updatedPermissionSpec := updatedPermission.ToPermissionSpec()
-	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePermission, updatedPermission.GetPermissionId(), updatedPermissionSpec)
+	err = svc.EventSvc.TrackResourceUpdated(ctx, ResourceTypePermission, updatedPermission.GetPermissionId(), updatedPermissionSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -119,17 +119,17 @@ func (svc PermissionService) UpdateByPermissionId(ctx context.Context, permissio
 
 func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissionId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.repo.DeleteByPermissionId(txCtx, permissionId)
+		err := svc.Repository.DeleteByPermissionId(txCtx, permissionId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.objectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePermission, permissionId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePermission, permissionId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -14,44 +14,44 @@ const ResourceTypePricingTier = "pricing-tier"
 
 type PricingTierService struct {
 	service.BaseService
-	repo      PricingTierRepository
-	eventSvc  event.EventService
-	objectSvc object.ObjectService
+	Repository PricingTierRepository
+	EventSvc   event.EventService
+	ObjectSvc  object.ObjectService
 }
 
-func NewService(env service.Env, repo PricingTierRepository, eventSvc event.EventService, objectSvc object.ObjectService) PricingTierService {
+func NewService(env service.Env, repository PricingTierRepository, eventSvc event.EventService, objectSvc object.ObjectService) PricingTierService {
 	return PricingTierService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
-		objectSvc:   objectSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
+		ObjectSvc:   objectSvc,
 	}
 }
 
 func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec PricingTierSpec) (*PricingTierSpec, error) {
 	var newPricingTier Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.objectSvc.Create(txCtx, *pricingTierSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *pricingTierSpec.ToObjectSpec())
 		if err != nil {
 			return err
 		}
 
-		_, err = svc.repo.GetByPricingTierId(txCtx, pricingTierSpec.PricingTierId)
+		_, err = svc.Repository.GetByPricingTierId(txCtx, pricingTierSpec.PricingTierId)
 		if err == nil {
 			return service.NewDuplicateRecordError("PricingTier", pricingTierSpec.PricingTierId, "A pricing tier with the given pricingTierId already exists")
 		}
 
-		newPricingTierId, err := svc.repo.Create(txCtx, pricingTierSpec.ToPricingTier(createdObject.ID))
+		newPricingTierId, err := svc.Repository.Create(txCtx, pricingTierSpec.ToPricingTier(createdObject.ID))
 		if err != nil {
 			return err
 		}
 
-		newPricingTier, err = svc.repo.GetById(txCtx, newPricingTierId)
+		newPricingTier, err = svc.Repository.GetById(txCtx, newPricingTierId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
 		if err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec Pricin
 }
 
 func (svc PricingTierService) GetByPricingTierId(ctx context.Context, pricingTierId string) (*PricingTierSpec, error) {
-	pricingTier, err := svc.repo.GetByPricingTierId(ctx, pricingTierId)
+	pricingTier, err := svc.Repository.GetByPricingTierId(ctx, pricingTierId)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (svc PricingTierService) GetByPricingTierId(ctx context.Context, pricingTie
 func (svc PricingTierService) List(ctx context.Context, listParams middleware.ListParams) ([]PricingTierSpec, error) {
 	pricingTierSpecs := make([]PricingTierSpec, 0)
 
-	pricingTiers, err := svc.repo.List(ctx, listParams)
+	pricingTiers, err := svc.Repository.List(ctx, listParams)
 	if err != nil {
 		return pricingTierSpecs, nil
 	}
@@ -91,25 +91,25 @@ func (svc PricingTierService) List(ctx context.Context, listParams middleware.Li
 }
 
 func (svc PricingTierService) UpdateByPricingTierId(ctx context.Context, pricingTierId string, pricingTierSpec UpdatePricingTierSpec) (*PricingTierSpec, error) {
-	currentPricingTier, err := svc.repo.GetByPricingTierId(ctx, pricingTierId)
+	currentPricingTier, err := svc.Repository.GetByPricingTierId(ctx, pricingTierId)
 	if err != nil {
 		return nil, err
 	}
 
 	currentPricingTier.SetName(pricingTierSpec.Name)
 	currentPricingTier.SetDescription(pricingTierSpec.Description)
-	err = svc.repo.UpdateByPricingTierId(ctx, pricingTierId, currentPricingTier)
+	err = svc.Repository.UpdateByPricingTierId(ctx, pricingTierId, currentPricingTier)
 	if err != nil {
 		return nil, err
 	}
 
-	updatedPricingTier, err := svc.repo.GetByPricingTierId(ctx, pricingTierId)
+	updatedPricingTier, err := svc.Repository.GetByPricingTierId(ctx, pricingTierId)
 	if err != nil {
 		return nil, err
 	}
 
 	updatedPricingTierSpec := updatedPricingTier.ToPricingTierSpec()
-	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypePricingTier, updatedPricingTier.GetPricingTierId(), updatedPricingTierSpec)
+	err = svc.EventSvc.TrackResourceUpdated(ctx, ResourceTypePricingTier, updatedPricingTier.GetPricingTierId(), updatedPricingTierSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -119,17 +119,17 @@ func (svc PricingTierService) UpdateByPricingTierId(ctx context.Context, pricing
 
 func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.repo.DeleteByPricingTierId(txCtx, pricingTierId)
+		err := svc.Repository.DeleteByPricingTierId(txCtx, pricingTierId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.objectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePricingTier, pricingTierId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePricingTier, pricingTierId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -79,7 +79,7 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 }
 
 func (svc UserService) GetByUserId(ctx context.Context, userId string) (*UserSpec, error) {
-	user, err := svc.repo.GetByUserId(ctx, userId)
+	user, err := svc.Repository.GetByUserId(ctx, userId)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func (svc UserService) GetByUserId(ctx context.Context, userId string) (*UserSpe
 func (svc UserService) List(ctx context.Context, listParams middleware.ListParams) ([]UserSpec, error) {
 	userSpecs := make([]UserSpec, 0)
 
-	users, err := svc.repo.List(ctx, listParams)
+	users, err := svc.Repository.List(ctx, listParams)
 	if err != nil {
 		return userSpecs, err
 	}
@@ -130,7 +130,7 @@ func (svc UserService) UpdateByUserId(ctx context.Context, userId string, userSp
 
 func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.repo.DeleteByUserId(txCtx, userId)
+		err := svc.Repository.DeleteByUserId(txCtx, userId)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -16,17 +16,17 @@ const ResourceTypeUser = "user"
 
 type UserService struct {
 	service.BaseService
-	repo      UserRepository
-	eventSvc  event.EventService
-	objectSvc object.ObjectService
+	Repository UserRepository
+	EventSvc   event.EventService
+	ObjectSvc  object.ObjectService
 }
 
-func NewService(env service.Env, repo UserRepository, eventSvc event.EventService, objectSvc object.ObjectService) UserService {
+func NewService(env service.Env, repository UserRepository, eventSvc event.EventService, objectSvc object.ObjectService) UserService {
 	return UserService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
-		eventSvc:    eventSvc,
-		objectSvc:   objectSvc,
+		Repository:  repository,
+		EventSvc:    eventSvc,
+		ObjectSvc:   objectSvc,
 	}
 }
 
@@ -38,7 +38,7 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 
 	var newUser Model
 	err = svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.objectSvc.Create(txCtx, *userSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *userSpec.ToObjectSpec())
 		if err != nil {
 			switch err.(type) {
 			case *service.DuplicateRecordError:
@@ -48,22 +48,22 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 			}
 		}
 
-		_, err = svc.repo.GetByUserId(txCtx, userSpec.UserId)
+		_, err = svc.Repository.GetByUserId(txCtx, userSpec.UserId)
 		if err == nil {
 			return service.NewDuplicateRecordError("User", userSpec.UserId, "A user with the given userId already exists")
 		}
 
-		newUserId, err := svc.repo.Create(txCtx, userSpec.ToUser(createdObject.ID))
+		newUserId, err := svc.Repository.Create(txCtx, userSpec.ToUser(createdObject.ID))
 		if err != nil {
 			return err
 		}
 
-		newUser, err = svc.repo.GetById(txCtx, newUserId)
+		newUser, err = svc.Repository.GetById(txCtx, newUserId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
 		if err != nil {
 			return err
 		}
@@ -103,24 +103,24 @@ func (svc UserService) List(ctx context.Context, listParams middleware.ListParam
 }
 
 func (svc UserService) UpdateByUserId(ctx context.Context, userId string, userSpec UpdateUserSpec) (*UserSpec, error) {
-	currentUser, err := svc.repo.GetByUserId(ctx, userId)
+	currentUser, err := svc.Repository.GetByUserId(ctx, userId)
 	if err != nil {
 		return nil, err
 	}
 
 	currentUser.SetEmail(userSpec.Email)
-	err = svc.repo.UpdateByUserId(ctx, userId, currentUser)
+	err = svc.Repository.UpdateByUserId(ctx, userId, currentUser)
 	if err != nil {
 		return nil, err
 	}
 
-	updatedUser, err := svc.repo.GetByUserId(ctx, userId)
+	updatedUser, err := svc.Repository.GetByUserId(ctx, userId)
 	if err != nil {
 		return nil, err
 	}
 
 	updatedUserSpec := updatedUser.ToUserSpec()
-	err = svc.eventSvc.TrackResourceUpdated(ctx, ResourceTypeUser, updatedUser.GetUserId(), updatedUserSpec)
+	err = svc.EventSvc.TrackResourceUpdated(ctx, ResourceTypeUser, updatedUser.GetUserId(), updatedUserSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +135,12 @@ func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error 
 			return err
 		}
 
-		err = svc.objectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeUser, userId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeUser, userId)
 		if err != nil {
 			return err
 		}
 
-		err = svc.eventSvc.TrackResourceDeleted(ctx, ResourceTypeUser, userId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeUser, userId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/context/service.go
+++ b/pkg/context/service.go
@@ -8,18 +8,18 @@ import (
 
 type ContextService struct {
 	service.BaseService
-	repo ContextRepository
+	Repository ContextRepository
 }
 
-func NewService(env service.Env, repo ContextRepository) ContextService {
+func NewService(env service.Env, repository ContextRepository) ContextService {
 	return ContextService{
 		BaseService: service.NewBaseService(env),
-		repo:        repo,
+		Repository:  repository,
 	}
 }
 
 func (svc ContextService) CreateAll(ctx context.Context, warrantId int64, spec ContextSetSpec) (ContextSetSpec, error) {
-	contexts, err := svc.repo.CreateAll(ctx, spec.ToSlice(warrantId))
+	contexts, err := svc.Repository.CreateAll(ctx, spec.ToSlice(warrantId))
 	if err != nil {
 		return nil, err
 	}
@@ -28,7 +28,7 @@ func (svc ContextService) CreateAll(ctx context.Context, warrantId int64, spec C
 }
 
 func (svc ContextService) ListByWarrantId(ctx context.Context, warrantIds []int64) (map[int64]ContextSetSpec, error) {
-	contexts, err := svc.repo.ListByWarrantId(ctx, warrantIds)
+	contexts, err := svc.Repository.ListByWarrantId(ctx, warrantIds)
 	if err != nil {
 		return nil, err
 	}
@@ -47,5 +47,5 @@ func (svc ContextService) ListByWarrantId(ctx context.Context, warrantIds []int6
 }
 
 func (svc ContextService) DeleteAllByWarrantId(ctx context.Context, warrantId int64) error {
-	return svc.repo.DeleteAllByWarrantId(ctx, warrantId)
+	return svc.Repository.DeleteAllByWarrantId(ctx, warrantId)
 }

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -22,14 +22,14 @@ const (
 
 type EventService struct {
 	service.BaseService
-	repo              EventRepository
+	Repository        EventRepository
 	synchronizeEvents bool
 }
 
-func NewService(env service.Env, repo EventRepository, synchronizeEvents bool) EventService {
+func NewService(env service.Env, repository EventRepository, synchronizeEvents bool) EventService {
 	return EventService{
 		BaseService:       service.NewBaseService(env),
-		repo:              repo,
+		Repository:        repository,
 		synchronizeEvents: synchronizeEvents,
 	}
 }
@@ -72,7 +72,7 @@ func (svc EventService) TrackResourceEvent(ctx context.Context, resourceEventSpe
 				log.Err(err).Msgf("Error tracking resource event %s", resourceEventSpec.Type)
 			}
 
-			err = svc.repo.TrackResourceEvent(context.Background(), *resourceEvent)
+			err = svc.Repository.TrackResourceEvent(context.Background(), *resourceEvent)
 			if err != nil {
 				log.Err(err).Msgf("Error tracking resource event %s", resourceEvent.Type)
 			}
@@ -85,7 +85,7 @@ func (svc EventService) TrackResourceEvent(ctx context.Context, resourceEventSpe
 		return err
 	}
 
-	return svc.repo.TrackResourceEvent(ctx, *resourceEvent)
+	return svc.Repository.TrackResourceEvent(ctx, *resourceEvent)
 }
 
 func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSpecs []CreateResourceEventSpec) error {
@@ -101,7 +101,7 @@ func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSp
 				resourceEvents = append(resourceEvents, *resourceEvent)
 			}
 
-			err := svc.repo.TrackResourceEvents(context.Background(), resourceEvents)
+			err := svc.Repository.TrackResourceEvents(context.Background(), resourceEvents)
 			if err != nil {
 				log.Err(err).Msgf("Error tracking resource events")
 			}
@@ -119,12 +119,12 @@ func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSp
 		resourceEvents = append(resourceEvents, *resourceEvent)
 	}
 
-	return svc.repo.TrackResourceEvents(ctx, resourceEvents)
+	return svc.Repository.TrackResourceEvents(ctx, resourceEvents)
 }
 
 func (svc EventService) ListResourceEvents(ctx context.Context, listParams ListResourceEventParams) ([]ResourceEventSpec, string, error) {
 	resourceEventSpecs := make([]ResourceEventSpec, 0)
-	resourceEvents, lastId, err := svc.repo.ListResourceEvents(ctx, listParams)
+	resourceEvents, lastId, err := svc.Repository.ListResourceEvents(ctx, listParams)
 	if err != nil {
 		return resourceEventSpecs, lastId, err
 	}
@@ -205,7 +205,7 @@ func (svc EventService) TrackAccessEvent(ctx context.Context, accessEventSpec Cr
 				log.Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
 			}
 
-			err = svc.repo.TrackAccessEvent(context.Background(), *accessEvent)
+			err = svc.Repository.TrackAccessEvent(context.Background(), *accessEvent)
 			if err != nil {
 				log.Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
 			}
@@ -218,7 +218,7 @@ func (svc EventService) TrackAccessEvent(ctx context.Context, accessEventSpec Cr
 		return err
 	}
 
-	return svc.repo.TrackAccessEvent(ctx, *accessEvent)
+	return svc.Repository.TrackAccessEvent(ctx, *accessEvent)
 }
 
 func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs []CreateAccessEventSpec) error {
@@ -234,7 +234,7 @@ func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs 
 				accessEvents = append(accessEvents, *accessEvent)
 			}
 
-			err := svc.repo.TrackAccessEvents(context.Background(), accessEvents)
+			err := svc.Repository.TrackAccessEvents(context.Background(), accessEvents)
 			if err != nil {
 				log.Err(err).Msg("Error tracking access events")
 			}
@@ -252,12 +252,12 @@ func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs 
 		accessEvents = append(accessEvents, *accessEvent)
 	}
 
-	return svc.repo.TrackAccessEvents(ctx, accessEvents)
+	return svc.Repository.TrackAccessEvents(ctx, accessEvents)
 }
 
 func (svc EventService) ListAccessEvents(ctx context.Context, listParams ListAccessEventParams) ([]AccessEventSpec, string, error) {
 	accessEventSpecs := make([]AccessEventSpec, 0)
-	accessEvents, lastId, err := svc.repo.ListAccessEvents(ctx, listParams)
+	accessEvents, lastId, err := svc.Repository.ListAccessEvents(ctx, listParams)
 	if err != nil {
 		return accessEventSpecs, lastId, err
 	}


### PR DESCRIPTION
This PR exports the repository and services in `XService` types, in order to allow them to be extended by allowing new types to embed the service and override the repository or service struct fields.