### PR TITLE
Set event createdAt to Now() from within query

### DIFF
--- a/pkg/event/spec.go
+++ b/pkg/event/spec.go
@@ -38,6 +38,7 @@ func (spec CreateResourceEventSpec) ToResourceEvent() (*ResourceEvent, error) {
 		ResourceType: spec.ResourceType,
 		ResourceId:   spec.ResourceId,
 		Meta:         database.StringToNullString(meta),
+		CreatedAt:    time.Now().UTC(),
 	}, nil
 }
 
@@ -99,6 +100,7 @@ func (spec CreateAccessEventSpec) ToAccessEvent() (*AccessEvent, error) {
 		SubjectRelation: spec.SubjectRelation,
 		Meta:            database.StringToNullString(meta),
 		Context:         database.StringToNullString(ctx),
+		CreatedAt:       time.Now().UTC(),
 	}, nil
 }
 

--- a/pkg/event/sqlite.go
+++ b/pkg/event/sqlite.go
@@ -40,14 +40,16 @@ func (repo SQLiteRepository) TrackResourceEvents(ctx context.Context, models []R
 			  source,
 			  resourceType,
 			  resourceId,
-			  meta
+			  meta,
+			  createdAt
 		   ) VALUES (
 			  :id,
 			  :type,
 			  :source,
 			  :resourceType,
 			  :resourceId,
-			  :meta
+			  :meta,
+			  :createdAt
 		   )
 		`,
 		resourceEvents,
@@ -171,7 +173,8 @@ func (repo SQLiteRepository) TrackAccessEvents(ctx context.Context, models []Acc
 			  subjectId,
 			  subjectRelation,
 			  context,
-			  meta
+			  meta,
+			  createdAt
 		   ) VALUES (
 			  :id,
 			  :type,
@@ -183,7 +186,8 @@ func (repo SQLiteRepository) TrackAccessEvents(ctx context.Context, models []Acc
 			  :subjectId,
 			  :subjectRelation,
 			  :context,
-			  :meta
+			  :meta,
+			  :createdAt
 		   )
 		`,
 		accessEvents,


### PR DESCRIPTION
This makes the event timestamps consistent with the precision used within the core warrant tables:

`2023-04-21 17:50:18.226966+00:00`