### PR TITLE
Feat/remove object type from event type column

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,6 +43,7 @@ jobs:
           WARRANT_PORT: 8000
           WARRANT_LOGLEVEL: 0
           WARRANT_ENABLEACCESSLOG: true
+          WARRANT_APIKEY: warrant_api_key
           WARRANT_DATASTORE: sqlite
           WARRANT_DATASTORE_SQLITE_DATABASE: warrant
           WARRANT_DATASTORE_SQLITE_INMEMORY: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,9 +47,11 @@ jobs:
           WARRANT_DATASTORE: sqlite
           WARRANT_DATASTORE_SQLITE_DATABASE: warrant
           WARRANT_DATASTORE_SQLITE_INMEMORY: true
+          WARRANT_DATASTORE_SQLITE_MIGRATIONSOURCE: file://./migrations/datastore/sqlite
           WARRANT_EVENTSTORE: sqlite
           WARRANT_EVENTSTORE_SQLITE_DATABASE: warrantEvents
           WARRANT_EVENTSTORE_SQLITE_INMEMORY: true
+          WARRANT_EVENTSTORE_SQLITE_MIGRATIONSOURCE: file://./migrations/eventstore/sqlite
           WARRANT_EVENTSTORE_SYNCHRONIZEEVENTS: true
       - name: Run apirunner tests
         run: |

--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -26,11 +26,11 @@ import (
 
 const (
 	MySQLDatastoreMigrationVersion     = 000003
-	MySQLEventstoreMigrationVersion    = 000001
+	MySQLEventstoreMigrationVersion    = 000002
 	PostgresDatastoreMigrationVersion  = 000003
-	PostgresEventstoreMigrationVersion = 000001
+	PostgresEventstoreMigrationVersion = 000002
 	SQLiteDatastoreMigrationVersion    = 000003
-	SQLiteEventstoreMigrationVersion   = 000001
+	SQLiteEventstoreMigrationVersion   = 000002
 )
 
 type ServiceEnv struct {

--- a/migrations/eventstore/mysql/000002_remove_object_type_prefix_from_event_type_columns.down.sql
+++ b/migrations/eventstore/mysql/000002_remove_object_type_prefix_from_event_type_columns.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE accessEvent
+SET type = CONCAT(objectType, ".", type);
+
+UPDATE resourceEvent
+SET type = CONCAT(resourceType, ".", type);
+
+COMMIT;

--- a/migrations/eventstore/mysql/000002_remove_object_type_prefix_from_event_type_columns.up.sql
+++ b/migrations/eventstore/mysql/000002_remove_object_type_prefix_from_event_type_columns.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE accessEvent
+SET type = SUBSTRING_INDEX(type, ".", -1);
+
+UPDATE resourceEvent
+SET type = SUBSTRING_INDEX(type, ".", -1);
+
+COMMIT;

--- a/migrations/eventstore/postgres/000002_remove_object_type_prefix_from_event_type_columns.down.sql
+++ b/migrations/eventstore/postgres/000002_remove_object_type_prefix_from_event_type_columns.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE access_event
+SET type = CONCAT(object_type, '.', type);
+
+UPDATE resource_event
+SET type = CONCAT(resource_type, '.', type);
+
+COMMIT;

--- a/migrations/eventstore/postgres/000002_remove_object_type_prefix_from_event_type_columns.up.sql
+++ b/migrations/eventstore/postgres/000002_remove_object_type_prefix_from_event_type_columns.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+UPDATE access_event
+SET type = SUBSTR(type, STRPOS(type, '.') + 1);
+
+UPDATE resource_event
+SET type = SUBSTR(type, STRPOS(type, '.') + 1);
+
+COMMIT;

--- a/migrations/eventstore/sqlite/000002_remove_object_type_prefix_from_event_type_columns.down.sql
+++ b/migrations/eventstore/sqlite/000002_remove_object_type_prefix_from_event_type_columns.down.sql
@@ -1,0 +1,5 @@
+UPDATE accessEvent
+SET type = objectType || "." || type;
+
+UPDATE resourceEvent
+SET type = resourceType || "." || type;

--- a/migrations/eventstore/sqlite/000002_remove_object_type_prefix_from_event_type_columns.up.sql
+++ b/migrations/eventstore/sqlite/000002_remove_object_type_prefix_from_event_type_columns.up.sql
@@ -1,0 +1,5 @@
+UPDATE accessEvent
+SET type = SUBSTR(type, INSTR(type, '.') + 1);
+
+UPDATE resourceEvent
+SET type = SUBSTR(type, INSTR(type, '.') + 1);

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -2,7 +2,6 @@ package event
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/rs/zerolog/log"
 	wntContext "github.com/warrant-dev/warrant/pkg/context"
@@ -36,7 +35,7 @@ func NewService(env service.Env, repository EventRepository, synchronizeEvents b
 
 func (svc EventService) TrackResourceCreated(ctx context.Context, resourceType string, resourceId string, meta interface{}) error {
 	return svc.TrackResourceEvent(ctx, CreateResourceEventSpec{
-		Type:         fmt.Sprintf("%s.%s", resourceType, EventTypeCreated),
+		Type:         EventTypeCreated,
 		Source:       EventSourceApi,
 		ResourceType: resourceType,
 		ResourceId:   resourceId,
@@ -46,7 +45,7 @@ func (svc EventService) TrackResourceCreated(ctx context.Context, resourceType s
 
 func (svc EventService) TrackResourceUpdated(ctx context.Context, resourceType string, resourceId string, meta interface{}) error {
 	return svc.TrackResourceEvent(ctx, CreateResourceEventSpec{
-		Type:         fmt.Sprintf("%s.%s", resourceType, EventTypeUpdated),
+		Type:         EventTypeUpdated,
 		Source:       EventSourceApi,
 		ResourceType: resourceType,
 		ResourceId:   resourceId,
@@ -56,7 +55,7 @@ func (svc EventService) TrackResourceUpdated(ctx context.Context, resourceType s
 
 func (svc EventService) TrackResourceDeleted(ctx context.Context, resourceType string, resourceId string, meta interface{}) error {
 	return svc.TrackResourceEvent(ctx, CreateResourceEventSpec{
-		Type:         fmt.Sprintf("%s.%s", resourceType, EventTypeDeleted),
+		Type:         EventTypeDeleted,
 		Source:       EventSourceApi,
 		ResourceType: resourceType,
 		ResourceId:   resourceId,
@@ -143,7 +142,7 @@ func (svc EventService) ListResourceEvents(ctx context.Context, listParams ListR
 
 func (svc EventService) TrackAccessGrantedEvent(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, wntCtx wntContext.ContextSetSpec) error {
 	return svc.TrackAccessEvent(ctx, CreateAccessEventSpec{
-		Type:            fmt.Sprintf("%s.%s", objectType, EventTypeAccessGranted),
+		Type:            EventTypeAccessGranted,
 		Source:          EventSourceApi,
 		ObjectType:      objectType,
 		ObjectId:        objectId,
@@ -157,7 +156,7 @@ func (svc EventService) TrackAccessGrantedEvent(ctx context.Context, objectType 
 
 func (svc EventService) TrackAccessRevokedEvent(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, wntCtx wntContext.ContextSetSpec) error {
 	return svc.TrackAccessEvent(ctx, CreateAccessEventSpec{
-		Type:            fmt.Sprintf("%s.%s", objectType, EventTypeAccessRevoked),
+		Type:            EventTypeAccessRevoked,
 		Source:          EventSourceApi,
 		ObjectType:      objectType,
 		ObjectId:        objectId,
@@ -171,7 +170,7 @@ func (svc EventService) TrackAccessRevokedEvent(ctx context.Context, objectType 
 
 func (svc EventService) TrackAccessAllowedEvent(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, wntCtx wntContext.ContextSetSpec) error {
 	return svc.TrackAccessEvent(ctx, CreateAccessEventSpec{
-		Type:            fmt.Sprintf("%s.%s", objectType, EventTypeAccessAllowed),
+		Type:            EventTypeAccessAllowed,
 		Source:          EventSourceApi,
 		ObjectType:      objectType,
 		ObjectId:        objectId,
@@ -185,7 +184,7 @@ func (svc EventService) TrackAccessAllowedEvent(ctx context.Context, objectType 
 
 func (svc EventService) TrackAccessDeniedEvent(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, wntCtx wntContext.ContextSetSpec) error {
 	return svc.TrackAccessEvent(ctx, CreateAccessEventSpec{
-		Type:            fmt.Sprintf("%s.%s", objectType, EventTypeAccessDenied),
+		Type:            EventTypeAccessDenied,
 		Source:          EventSourceApi,
 		ObjectType:      objectType,
 		ObjectId:        objectId,

--- a/tests/ci-apirunner.conf
+++ b/tests/ci-apirunner.conf
@@ -1,5 +1,6 @@
 {
     "baseUrl": "http://localhost:8000",
     "headers": {
+        "Authorization": "ApiKey warrant_api_key"
     }
 }

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -15,19 +15,19 @@
                 "body": {
                     "events": [
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
                         },
                         {
-                            "type": "role.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "role",
                             "resourceId": "senior-accountant"
                         },
                         {
-                            "type": "permission.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "permission",
                             "resourceId": "view-balance-sheet"
@@ -48,13 +48,13 @@
                 "body": {
                     "events": [
                         {
-                            "type": "permission.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "permission",
                             "resourceId": "edit-balance-sheet"
                         },
                         {
-                            "type": "permission.created",
+                            "type": "created",
                             "source": "api",
                             "resourceType": "permission",
                             "resourceId": "edit-balance-sheet",
@@ -86,41 +86,41 @@
             "name": "listResourceEventsFilterByType",
             "request": {
                 "method": "GET",
-                "url": "/v1/resource-events?limit=5&type=user.deleted"
+                "url": "/v1/resource-events?limit=5&type=deleted"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "events": [
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
+                            "source": "api",
+                            "resourceType": "role",
+                            "resourceId": "senior-accountant"
+                        },
+                        {
+                            "type": "deleted",
+                            "source": "api",
+                            "resourceType": "permission",
+                            "resourceId": "view-balance-sheet"
+                        },
+                        {
+                            "type": "deleted",
+                            "source": "api",
+                            "resourceType": "permission",
+                            "resourceId": "edit-balance-sheet"
+                        },
+                        {
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-5"
-                        },
-                        {
-                            "type": "user.deleted",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-4"
-                        },
-                        {
-                            "type": "user.deleted",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-3"
-                        },
-                        {
-                            "type": "user.deleted",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-2"
                         }
                     ],
                     "lastId": "{{ listResourceEventsFilterByType.lastId }}"
@@ -138,13 +138,13 @@
                 "body": {
                     "events": [
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
                         },
                         {
-                            "type": "user.created",
+                            "type": "created",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a",
@@ -154,19 +154,19 @@
                             }
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-5"
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-4"
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-3"
@@ -187,13 +187,13 @@
                 "body": {
                     "events": [
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
                         },
                         {
-                            "type": "user.created",
+                            "type": "created",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a",
@@ -203,13 +203,13 @@
                             }
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
                         },
                         {
-                            "type": "user.created",
+                            "type": "created",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a",
@@ -219,7 +219,7 @@
                             }
                         },
                         {
-                            "type": "user.deleted",
+                            "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-a"
@@ -240,7 +240,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "permission.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "view-balance-sheet",
@@ -249,7 +249,7 @@
                             "subjectId": "senior-accountant"
                         },
                         {
-                            "type": "permission.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "edit-balance-sheet",
@@ -258,7 +258,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "role.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "role",
                             "objectId": "senior-accountant",
@@ -282,7 +282,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "role.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "role",
                             "objectId": "senior-accountant",
@@ -291,7 +291,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "permission.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "edit-balance-sheet",
@@ -321,14 +321,23 @@
             "name": "listAccessEventsFilterByType",
             "request": {
                 "method": "GET",
-                "url": "/v1/access-events?limit=4&type=permission.access_granted"
+                "url": "/v1/access-events?limit=4&type=access_granted"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "events": [
                         {
-                            "type": "permission.access_granted",
+                            "type": "access_granted",
+                            "source": "api",
+                            "objectType": "role",
+                            "objectId": "senior-accountant",
+                            "relation": "member",
+                            "subjectType": "user",
+                            "subjectId": "user-a"
+                        },
+                        {
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "edit-balance-sheet",
@@ -337,7 +346,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "permission.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "view-balance-sheet",
@@ -346,22 +355,13 @@
                             "subjectId": "senior-accountant"
                         },
                         {
-                            "type": "permission.access_granted",
+                            "type": "access_granted",
                             "source": "api",
-                            "objectType": "permission",
-                            "objectId": "edit-balance-sheet",
+                            "objectType": "pricing-tier",
+                            "objectId": "enterprise",
                             "relation": "member",
-                            "subjectType": "role",
-                            "subjectId": "senior-accountant"
-                        },
-                        {
-                            "type": "permission.access_granted",
-                            "source": "api",
-                            "objectType": "permission",
-                            "objectId": "view-balance-sheet",
-                            "relation": "member",
-                            "subjectType": "role",
-                            "subjectId": "senior-accountant"
+                            "subjectType": "tenant",
+                            "subjectId": "tenant2-enterprise"
                         }
                     ],
                     "lastId": "{{ listAccessEventsFilterByType.lastId }}"
@@ -379,7 +379,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "report.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -388,7 +388,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -397,7 +397,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -406,7 +406,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -415,7 +415,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -439,7 +439,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "report.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -448,7 +448,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -457,7 +457,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -466,7 +466,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -475,7 +475,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -499,7 +499,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -508,7 +508,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -517,7 +517,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -526,7 +526,7 @@
                             "subjectId": "user-f"
                         },
                         {
-                            "type": "report.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -535,7 +535,7 @@
                             "subjectId": "user-e"
                         },
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -559,7 +559,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "permission.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "edit-balance-sheet",
@@ -568,7 +568,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "role.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "role",
                             "objectId": "senior-accountant",
@@ -577,7 +577,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "role.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "role",
                             "objectId": "senior-accountant",
@@ -586,7 +586,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "permission.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "permission",
                             "objectId": "edit-balance-sheet",
@@ -595,7 +595,7 @@
                             "subjectId": "user-a"
                         },
                         {
-                            "type": "feature.access_allowed",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "feature",
                             "objectId": "analytics",
@@ -619,7 +619,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "role.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "role",
                             "objectId": "admin-a",
@@ -628,7 +628,7 @@
                             "subjectId": "user-c"
                         },
                         {
-                            "type": "report.access_denied",
+                            "type": "access_denied",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-b",
@@ -652,7 +652,7 @@
                 "body": {
                     "events": [
                         {
-                            "type": "report.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "*",
@@ -662,7 +662,7 @@
                             "subjectRelation": "member"
                         },
                         {
-                            "type": "report.access_revoked",
+                            "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "*",
@@ -672,7 +672,7 @@
                             "subjectRelation": "member"
                         },
                         {
-                            "type": "report.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "*",
@@ -682,7 +682,7 @@
                             "subjectRelation": "member"
                         },
                         {
-                            "type": "report.access_granted",
+                            "type": "access_granted",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "*",


### PR DESCRIPTION
Currently, the `type` column for both resource events and access events is prefixed with the type of the object/resource the event is for, followed by the actual event type. This is both redundant and makes it difficult to be able to filter events just by a type (e.g. `access_denied`, `created`, `deleted`, etc). As a result, this PR removes the object/resource type prefix on the event's `type` column (for both existing and new events).