### PR TITLE
Remove context from non-warrant specs

### DIFF
--- a/pkg/authz/feature/spec.go
+++ b/pkg/authz/feature/spec.go
@@ -5,16 +5,14 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	context "github.com/warrant-dev/warrant/pkg/context"
 	"github.com/warrant-dev/warrant/pkg/database"
 )
 
 type FeatureSpec struct {
-	FeatureId   string                 `json:"featureId" validate:"required"`
-	Name        database.NullString    `json:"name"`
-	Description database.NullString    `json:"description"`
-	Context     context.ContextSetSpec `json:"context,omitempty"`
-	CreatedAt   time.Time              `json:"createdAt"`
+	FeatureId   string              `json:"featureId" validate:"required"`
+	Name        database.NullString `json:"name"`
+	Description database.NullString `json:"description"`
+	CreatedAt   time.Time           `json:"createdAt"`
 }
 
 func (spec FeatureSpec) ToFeature(objectId int64) *Feature {

--- a/pkg/authz/permission/spec.go
+++ b/pkg/authz/permission/spec.go
@@ -5,16 +5,14 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	context "github.com/warrant-dev/warrant/pkg/context"
 	"github.com/warrant-dev/warrant/pkg/database"
 )
 
 type PermissionSpec struct {
-	PermissionId string                 `json:"permissionId" validate:"required"`
-	Name         database.NullString    `json:"name"`
-	Description  database.NullString    `json:"description"`
-	Context      context.ContextSetSpec `json:"context,omitempty"`
-	CreatedAt    time.Time              `json:"createdAt"`
+	PermissionId string              `json:"permissionId" validate:"required"`
+	Name         database.NullString `json:"name"`
+	Description  database.NullString `json:"description"`
+	CreatedAt    time.Time           `json:"createdAt"`
 }
 
 func (spec PermissionSpec) ToPermission(objectId int64) *Permission {

--- a/pkg/authz/pricingtier/spec.go
+++ b/pkg/authz/pricingtier/spec.go
@@ -5,16 +5,14 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	context "github.com/warrant-dev/warrant/pkg/context"
 	"github.com/warrant-dev/warrant/pkg/database"
 )
 
 type PricingTierSpec struct {
-	PricingTierId string                 `json:"pricingTierId" validate:"required"`
-	Name          database.NullString    `json:"name"`
-	Description   database.NullString    `json:"description"`
-	Context       context.ContextSetSpec `json:"context,omitempty"`
-	CreatedAt     time.Time              `json:"createdAt"`
+	PricingTierId string              `json:"pricingTierId" validate:"required"`
+	Name          database.NullString `json:"name"`
+	Description   database.NullString `json:"description"`
+	CreatedAt     time.Time           `json:"createdAt"`
 }
 
 func (spec PricingTierSpec) ToPricingTier(objectId int64) Model {

--- a/pkg/authz/role/spec.go
+++ b/pkg/authz/role/spec.go
@@ -5,16 +5,14 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	context "github.com/warrant-dev/warrant/pkg/context"
 	"github.com/warrant-dev/warrant/pkg/database"
 )
 
 type RoleSpec struct {
-	RoleId      string                 `json:"roleId" validate:"required"`
-	Name        database.NullString    `json:"name"`
-	Description database.NullString    `json:"description"`
-	Context     context.ContextSetSpec `json:"context,omitempty"`
-	CreatedAt   time.Time              `json:"createdAt"`
+	RoleId      string              `json:"roleId" validate:"required"`
+	Name        database.NullString `json:"name"`
+	Description database.NullString `json:"description"`
+	CreatedAt   time.Time           `json:"createdAt"`
 }
 
 func (spec RoleSpec) ToRole(objectId int64) *Role {


### PR DESCRIPTION
Context is a warrant concept that shouldn't be a field on the role, permission, pricingTier or feature spec types. This PR removes the context field from the mentioned spec definitions.