### PR TITLE
Track events within transactions

### DIFF
--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -127,13 +127,13 @@ func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId strin
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypeFeature, featureId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeFeature, featureId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -51,13 +51,13 @@ func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -51,7 +51,7 @@ func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypeFeature, newFeature.GetFeatureId(), newFeature.ToFeatureSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -51,13 +51,13 @@ func (svc PermissionService) Create(ctx context.Context, permissionSpec Permissi
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissio
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -51,7 +51,7 @@ func (svc PermissionService) Create(ctx context.Context, permissionSpec Permissi
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypePermission, newPermission.GetPermissionId(), newPermission.ToPermissionSpec())
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissio
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePermission, permissionId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypePermission, permissionId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -51,7 +51,7 @@ func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec Pricin
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricing
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypePricingTier, pricingTierId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -51,13 +51,13 @@ func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec Pricin
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypePricingTier, newPricingTier.GetPricingTierId(), newPricingTier.ToPricingTierSpec())
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricing
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypePricingTier, pricingTierId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/role/service.go
+++ b/pkg/authz/role/service.go
@@ -51,13 +51,13 @@ func (svc RoleService) Create(ctx context.Context, roleSpec RoleSpec) (*RoleSpec
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) error 
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeRole, roleId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeRole, roleId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/role/service.go
+++ b/pkg/authz/role/service.go
@@ -51,7 +51,7 @@ func (svc RoleService) Create(ctx context.Context, roleSpec RoleSpec) (*RoleSpec
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypeRole, newRole.GetRoleId(), newRole.ToRoleSpec())
 		if err != nil {
 			return err
 		}
@@ -128,7 +128,7 @@ func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) error 
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeRole, roleId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypeRole, roleId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/tenant/service.go
+++ b/pkg/authz/tenant/service.go
@@ -67,7 +67,7 @@ func (svc TenantService) Create(ctx context.Context, tenantSpec TenantSpec) (*Te
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
 		if err != nil {
 			return err
 		}
@@ -143,7 +143,7 @@ func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) 
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeTenant, tenantId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypeTenant, tenantId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/tenant/service.go
+++ b/pkg/authz/tenant/service.go
@@ -67,13 +67,13 @@ func (svc TenantService) Create(ctx context.Context, tenantSpec TenantSpec) (*Te
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeTenant, newTenant.GetTenantId(), newTenant.ToTenantSpec())
 	if err != nil {
 		return nil, err
 	}
@@ -143,13 +143,13 @@ func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) 
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeTenant, tenantId, nil)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeTenant, tenantId, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -67,13 +67,13 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 			return err
 		}
 
+		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -143,7 +143,7 @@ func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error 
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceDeleted(ctx, ResourceTypeUser, userId, nil)
+		err = svc.EventSvc.TrackResourceDeleted(txCtx, ResourceTypeUser, userId, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -67,7 +67,7 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 			return err
 		}
 
-		err = svc.EventSvc.TrackResourceCreated(ctx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
+		err = svc.EventSvc.TrackResourceCreated(txCtx, ResourceTypeUser, newUser.GetUserId(), newUser.ToUserSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -75,13 +75,13 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 			}
 		}
 
+		err = svc.EventSvc.TrackAccessGrantedEvent(ctx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return nil, err
-	}
-
-	err = svc.EventSvc.TrackAccessGrantedEvent(ctx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -155,13 +155,13 @@ func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) e
 			return err
 		}
 
+		err = svc.EventSvc.TrackAccessRevokedEvent(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	err = svc.EventSvc.TrackAccessRevokedEvent(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -75,7 +75,7 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 			}
 		}
 
-		err = svc.EventSvc.TrackAccessGrantedEvent(ctx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
+		err = svc.EventSvc.TrackAccessGrantedEvent(txCtx, createdWarrantSpec.ObjectType, createdWarrantSpec.ObjectId, createdWarrantSpec.Relation, createdWarrantSpec.Subject.ObjectType, createdWarrantSpec.Subject.ObjectId, createdWarrantSpec.Subject.Relation, warrantSpec.Context)
 		if err != nil {
 			return err
 		}
@@ -155,7 +155,7 @@ func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) e
 			return err
 		}
 
-		err = svc.EventSvc.TrackAccessRevokedEvent(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
+		err = svc.EventSvc.TrackAccessRevokedEvent(txCtx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
In this PR, event calls made in service methods containing a transaction are moved to be within the transaction. This allows the transaction to fail if the event call fails if event calls are being made synchronously. 