### PR TITLE
Use BeginTxx when running a transaction to pass context in

### DIFF
--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -150,7 +150,7 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 
 			panic(p)
 		} else if errors.Is(err, context.Canceled) {
-			err = errors.Wrap(err, "transaction rolled back")
+			err = errors.Wrap(err, "sql transaction rolled back")
 		} else if err != nil {
 			err = tx.Rollback()
 			if err != nil {

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -145,19 +145,24 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 		if p := recover(); p != nil {
 			err = tx.Rollback()
 			if err != nil {
-				log.Err(err).Msg("error rolling back sql transaction")
+				err = errors.Wrap(err, "error rolling back sql transaction")
+				log.Err(err).Msg("")
 			}
 
 			panic(p)
+		} else if errors.Is(err, context.Canceled) {
+			err = errors.Wrap(err, "transaction rolled back")
 		} else if err != nil {
 			err = tx.Rollback()
 			if err != nil {
-				log.Err(err).Msg("error rolling back sql transaction")
+				err = errors.Wrap(err, "error rolling back sql transaction")
+				log.Err(err).Msg("")
 			}
 		} else {
 			err = tx.Commit()
 			if err != nil {
-				log.Err(err).Msg("error committing sql transaction")
+				err = errors.Wrap(err, "error committing sql transaction")
+				log.Err(err).Msg("")
 			}
 		}
 	}()

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -136,7 +136,7 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 		return txFunc(ctx)
 	}
 
-	tx, err := ds.DB.Beginx()
+	tx, err := ds.DB.BeginTxx(ctx, nil)
 	if err != nil {
 		return errors.Wrap(err, "Error beginning sql transaction")
 	}

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -164,7 +164,8 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 
 	// Add the newly created transaction for this database to txCtx
 	ctxWithTx := context.WithValue(ctx, newTxKey(ds.DatabaseName), &SqlTx{Tx: tx})
-	return txFunc(ctxWithTx)
+	err = txFunc(ctxWithTx)
+	return err
 }
 
 func (ds SQL) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -146,7 +146,6 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 			err = tx.Rollback()
 			if err != nil {
 				err = errors.Wrap(err, "error rolling back sql transaction")
-				log.Err(err).Msg("")
 			}
 
 			panic(p)
@@ -156,13 +155,11 @@ func (ds SQL) WithinTransaction(ctx context.Context, txFunc func(txCtx context.C
 			err = tx.Rollback()
 			if err != nil {
 				err = errors.Wrap(err, "error rolling back sql transaction")
-				log.Err(err).Msg("")
 			}
 		} else {
 			err = tx.Commit()
 			if err != nil {
 				err = errors.Wrap(err, "error committing sql transaction")
-				log.Err(err).Msg("")
 			}
 		}
 	}()


### PR DESCRIPTION
This PR updates `WithinTransaction` to use `BeginTxx` from the `sqlx` package in order to pass in the request context when running a transaction . This allows `sqlx` to automatically handle DB rollbacks when there are any SQL errors, such as a context cancellation.