### PR TITLE
Update query param parsing

### DIFF
--- a/pkg/authz/feature/handlers.go
+++ b/pkg/authz/feature/handlers.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -71,12 +70,7 @@ func CreateHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) e
 }
 
 func GetHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) error {
-	featureIdParam := mux.Vars(r)["featureId"]
-	featureId, err := url.QueryUnescape(featureIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("featureId", "")
-	}
-
+	featureId := mux.Vars(r)["featureId"]
 	feature, err := svc.GetByFeatureId(r.Context(), featureId)
 	if err != nil {
 		return err
@@ -104,12 +98,7 @@ func UpdateHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) e
 		return err
 	}
 
-	featureIdParam := mux.Vars(r)["featureId"]
-	featureId, err := url.QueryUnescape(featureIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("featureId", "")
-	}
-
+	featureId := mux.Vars(r)["featureId"]
 	updatedFeature, err := svc.UpdateByFeatureId(r.Context(), featureId, updateFeature)
 	if err != nil {
 		return err

--- a/pkg/authz/object/handlers.go
+++ b/pkg/authz/object/handlers.go
@@ -77,8 +77,8 @@ func ListHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) erro
 
 func GetHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
 	objectType := mux.Vars(r)["objectType"]
-	objectIdParam := mux.Vars(r)["objectId"]
-	object, err := svc.GetByObjectTypeAndId(r.Context(), objectType, objectIdParam)
+	objectId := mux.Vars(r)["objectId"]
+	object, err := svc.GetByObjectTypeAndId(r.Context(), objectType, objectId)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/objecttype/handlers.go
+++ b/pkg/authz/objecttype/handlers.go
@@ -83,8 +83,8 @@ func ListHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request) 
 }
 
 func GetHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request) error {
-	typeParam := mux.Vars(r)["type"]
-	objectTypeSpec, err := svc.GetByTypeId(r.Context(), typeParam)
+	typeId := mux.Vars(r)["type"]
+	objectTypeSpec, err := svc.GetByTypeId(r.Context(), typeId)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,8 @@ func UpdateHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request
 		return err
 	}
 
-	typeParam := mux.Vars(r)["type"]
-	updatedObjectTypeSpec, err := svc.UpdateByTypeId(r.Context(), typeParam, objectTypeSpec)
+	typeId := mux.Vars(r)["type"]
+	updatedObjectTypeSpec, err := svc.UpdateByTypeId(r.Context(), typeId, objectTypeSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/permission/handlers.go
+++ b/pkg/authz/permission/handlers.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -71,12 +70,7 @@ func CreateHandler(svc PermissionService, w http.ResponseWriter, r *http.Request
 }
 
 func GetHandler(svc PermissionService, w http.ResponseWriter, r *http.Request) error {
-	permissionIdParam := mux.Vars(r)["permissionId"]
-	permissionId, err := url.QueryUnescape(permissionIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("permissionId", "")
-	}
-
+	permissionId := mux.Vars(r)["permissionId"]
 	permission, err := svc.GetByPermissionId(r.Context(), permissionId)
 	if err != nil {
 		return err
@@ -104,12 +98,7 @@ func UpdateHandler(svc PermissionService, w http.ResponseWriter, r *http.Request
 		return err
 	}
 
-	permissionIdParam := mux.Vars(r)["permissionId"]
-	permissionId, err := url.QueryUnescape(permissionIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("permissionId", "")
-	}
-
+	permissionId := mux.Vars(r)["permissionId"]
 	updatedPermission, err := svc.UpdateByPermissionId(r.Context(), permissionId, updatePermission)
 	if err != nil {
 		return err

--- a/pkg/authz/pricingtier/handlers.go
+++ b/pkg/authz/pricingtier/handlers.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -71,12 +70,7 @@ func CreateHandler(svc PricingTierService, w http.ResponseWriter, r *http.Reques
 }
 
 func GetHandler(svc PricingTierService, w http.ResponseWriter, r *http.Request) error {
-	pricingTierIdParam := mux.Vars(r)["pricingTierId"]
-	pricingTierId, err := url.QueryUnescape(pricingTierIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("pricingTierId", "")
-	}
-
+	pricingTierId := mux.Vars(r)["pricingTierId"]
 	pricingTier, err := svc.GetByPricingTierId(r.Context(), pricingTierId)
 	if err != nil {
 		return err
@@ -104,12 +98,7 @@ func UpdateHandler(svc PricingTierService, w http.ResponseWriter, r *http.Reques
 		return err
 	}
 
-	pricingTierIdParam := mux.Vars(r)["pricingTierId"]
-	pricingTierId, err := url.QueryUnescape(pricingTierIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("pricingTierId", "")
-	}
-
+	pricingTierId := mux.Vars(r)["pricingTierId"]
 	updatedPricingTier, err := svc.UpdateByPricingTierId(r.Context(), pricingTierId, updatePricingTier)
 	if err != nil {
 		return err

--- a/pkg/authz/role/handlers.go
+++ b/pkg/authz/role/handlers.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -71,12 +70,7 @@ func CreateHandler(svc RoleService, w http.ResponseWriter, r *http.Request) erro
 }
 
 func GetHandler(svc RoleService, w http.ResponseWriter, r *http.Request) error {
-	roleIdParam := mux.Vars(r)["roleId"]
-	roleId, err := url.QueryUnescape(roleIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("roleId", "")
-	}
-
+	roleId := mux.Vars(r)["roleId"]
 	role, err := svc.GetByRoleId(r.Context(), roleId)
 	if err != nil {
 		return err
@@ -104,12 +98,7 @@ func UpdateHandler(svc RoleService, w http.ResponseWriter, r *http.Request) erro
 		return err
 	}
 
-	roleIdParam := mux.Vars(r)["roleId"]
-	roleId, err := url.QueryUnescape(roleIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("roleId", "")
-	}
-
+	roleId := mux.Vars(r)["roleId"]
 	updatedRole, err := svc.UpdateByRoleId(r.Context(), roleId, updateRole)
 	if err != nil {
 		return err

--- a/pkg/authz/tenant/handlers.go
+++ b/pkg/authz/tenant/handlers.go
@@ -2,7 +2,6 @@ package tenant
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -71,12 +70,7 @@ func CreateHandler(svc TenantService, w http.ResponseWriter, r *http.Request) er
 }
 
 func GetHandler(svc TenantService, w http.ResponseWriter, r *http.Request) error {
-	tenantIdParam := mux.Vars(r)["tenantId"]
-	tenantId, err := url.QueryUnescape(tenantIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("tenantId", "")
-	}
-
+	tenantId := mux.Vars(r)["tenantId"]
 	tenant, err := svc.GetByTenantId(r.Context(), tenantId)
 	if err != nil {
 		return err
@@ -104,12 +98,7 @@ func UpdateHandler(svc TenantService, w http.ResponseWriter, r *http.Request) er
 		return err
 	}
 
-	tenantIdParam := mux.Vars(r)["tenantId"]
-	tenantId, err := url.QueryUnescape(tenantIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("tenantId", "")
-	}
-
+	tenantId := mux.Vars(r)["tenantId"]
 	updatedTenant, err := svc.UpdateByTenantId(r.Context(), tenantId, updateTenant)
 	if err != nil {
 		return err

--- a/pkg/authz/user/handlers.go
+++ b/pkg/authz/user/handlers.go
@@ -2,7 +2,6 @@ package authz
 
 import (
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -70,12 +69,7 @@ func CreateHandler(svc UserService, w http.ResponseWriter, r *http.Request) erro
 }
 
 func GetHandler(svc UserService, w http.ResponseWriter, r *http.Request) error {
-	userIdParam := mux.Vars(r)["userId"]
-	userId, err := url.QueryUnescape(userIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("userId", "")
-	}
-
+	userId := mux.Vars(r)["userId"]
 	user, err := svc.GetByUserId(r.Context(), userId)
 	if err != nil {
 		return err
@@ -103,12 +97,7 @@ func UpdateHandler(svc UserService, w http.ResponseWriter, r *http.Request) erro
 		return err
 	}
 
-	userIdParam := mux.Vars(r)["userId"]
-	userId, err := url.QueryUnescape(userIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("userId", "")
-	}
-
+	userId := mux.Vars(r)["userId"]
 	updatedUser, err := svc.UpdateByUserId(r.Context(), userId, updateUser)
 	if err != nil {
 		return err
@@ -119,13 +108,8 @@ func UpdateHandler(svc UserService, w http.ResponseWriter, r *http.Request) erro
 }
 
 func DeleteHandler(svc UserService, w http.ResponseWriter, r *http.Request) error {
-	userIdParam := mux.Vars(r)["userId"]
-	userId, err := url.QueryUnescape(userIdParam)
-	if err != nil {
-		return service.NewInvalidParameterError("userId", "")
-	}
-
-	err = svc.DeleteByUserId(r.Context(), userId)
+	userId := mux.Vars(r)["userId"]
+	err := svc.DeleteByUserId(r.Context(), userId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When fetching query param values using `mux.Vars`, the value returned is already unescaped. By calling `QueryUnescape` on the returned value, we unescape the value twice which can return unexpected values.