### PR TITLE
Handle wildcard objectIds in access checks

### DIFF
--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -68,7 +68,6 @@ func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType stri
 		wntCtx.ToHash(),
 	)
 	if err != nil {
-		log.Err(err).Msg("Error fetching warrants for object")
 		return warrantSpecs, err
 	}
 
@@ -105,7 +104,6 @@ func (svc CheckService) getMatchingSubjectsBySubjectType(ctx context.Context, ob
 		wntCtx.ToHash(),
 	)
 	if err != nil {
-		log.Err(err).Msg("Error fetching warrants for object")
 		return warrantSpecs, err
 	}
 

--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -112,7 +112,7 @@ func (svc CheckService) getMatchingSubjectsWithSubjectType(ctx context.Context, 
 		return warrantSpecs, nil
 	}
 
-	warrants, err := svc.WarrantRepository.GetAllMatchingObjectAndRelationWithSubjectType(
+	warrants, err := svc.WarrantRepository.GetAllMatchingObjectAndRelationBySubjectType(
 		ctx,
 		objectType,
 		objectId,

--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -80,22 +80,6 @@ func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType stri
 		return warrantSpecs, err
 	}
 
-	warrants, err = svc.WarrantRepository.GetAllMatchingWildcard(
-		ctx,
-		objectType,
-		objectId,
-		relation,
-		wntCtx.ToHash(),
-	)
-	if err != nil {
-		log.Err(err).Msg("Error fetching warrants matching wildcard")
-		return warrantSpecs, err
-	}
-
-	for _, warrant := range warrants {
-		warrantSpecs = append(warrantSpecs, *warrant.ToWarrantSpec())
-	}
-
 	return warrantSpecs, nil
 }
 
@@ -131,22 +115,6 @@ func (svc CheckService) getMatchingSubjectsWithSubjectType(ctx context.Context, 
 
 	if err != nil {
 		return warrantSpecs, err
-	}
-
-	warrants, err = svc.WarrantRepository.GetAllMatchingWildcard(
-		ctx,
-		objectType,
-		objectId,
-		relation,
-		wntCtx.ToHash(),
-	)
-	if err != nil {
-		log.Err(err).Msg("Error fetching warrants matching wildcard")
-		return warrantSpecs, err
-	}
-
-	for _, warrant := range warrants {
-		warrantSpecs = append(warrantSpecs, *warrant.ToWarrantSpec())
 	}
 
 	return warrantSpecs, nil

--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -83,7 +83,7 @@ func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType stri
 	return warrantSpecs, nil
 }
 
-func (svc CheckService) getMatchingSubjectsWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, wntCtx wntContext.ContextSetSpec) ([]warrant.WarrantSpec, error) {
+func (svc CheckService) getMatchingSubjectsBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, wntCtx wntContext.ContextSetSpec) ([]warrant.WarrantSpec, error) {
 	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@%s:___%s", objectType, objectId, relation, subjectType, wntCtx)
 
 	warrantSpecs := make([]warrant.WarrantSpec, 0)
@@ -187,7 +187,7 @@ func (svc CheckService) checkRule(ctx context.Context, authInfo *service.AuthInf
 			})
 		}
 
-		matchingWarrants, err := svc.getMatchingSubjectsWithSubjectType(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, rule.WithRelation, rule.OfType, warrantSpec.Context)
+		matchingWarrants, err := svc.getMatchingSubjectsBySubjectType(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, rule.WithRelation, rule.OfType, warrantSpec.Context)
 		if err != nil {
 			return false, decisionPath, err
 		}

--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -47,8 +47,8 @@ func (svc CheckService) getWithContextMatch(ctx context.Context, spec warrant.Wa
 	return warrantSpec, nil
 }
 
-func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType string, objectId string, relation string, subjectType string, wntCtx wntContext.ContextSetSpec) ([]warrant.WarrantSpec, error) {
-	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@%s:___%s", objectType, objectId, relation, subjectType, wntCtx)
+func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType string, objectId string, relation string, wntCtx wntContext.ContextSetSpec) ([]warrant.WarrantSpec, error) {
+	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@___%s", objectType, objectId, relation, wntCtx)
 
 	warrantSpecs := make([]warrant.WarrantSpec, 0)
 	objectTypeSpec, err := svc.ObjectTypeSvc.GetByTypeId(ctx, objectType)
@@ -61,6 +61,58 @@ func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType stri
 	}
 
 	warrants, err := svc.WarrantRepository.GetAllMatchingObjectAndRelation(
+		ctx,
+		objectType,
+		objectId,
+		relation,
+		wntCtx.ToHash(),
+	)
+	if err != nil {
+		log.Err(err).Msg("Error fetching warrants for object")
+		return warrantSpecs, err
+	}
+
+	for _, warrant := range warrants {
+		warrantSpecs = append(warrantSpecs, *warrant.ToWarrantSpec())
+	}
+
+	if err != nil {
+		return warrantSpecs, err
+	}
+
+	warrants, err = svc.WarrantRepository.GetAllMatchingWildcard(
+		ctx,
+		objectType,
+		objectId,
+		relation,
+		wntCtx.ToHash(),
+	)
+	if err != nil {
+		log.Err(err).Msg("Error fetching warrants matching wildcard")
+		return warrantSpecs, err
+	}
+
+	for _, warrant := range warrants {
+		warrantSpecs = append(warrantSpecs, *warrant.ToWarrantSpec())
+	}
+
+	return warrantSpecs, nil
+}
+
+func (svc CheckService) getMatchingSubjectsWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, wntCtx wntContext.ContextSetSpec) ([]warrant.WarrantSpec, error) {
+	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@%s:___%s", objectType, objectId, relation, subjectType, wntCtx)
+
+	warrantSpecs := make([]warrant.WarrantSpec, 0)
+	objectTypeSpec, err := svc.ObjectTypeSvc.GetByTypeId(ctx, objectType)
+	if err != nil {
+		return warrantSpecs, err
+	}
+
+	if _, ok := objectTypeSpec.Relations[relation]; !ok {
+		return warrantSpecs, nil
+	}
+
+	warrants, err := svc.WarrantRepository.GetAllMatchingObjectAndRelationWithSubjectType(
 		ctx,
 		objectType,
 		objectId,
@@ -167,7 +219,7 @@ func (svc CheckService) checkRule(ctx context.Context, authInfo *service.AuthInf
 			})
 		}
 
-		matchingWarrants, err := svc.getMatchingSubjects(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, rule.WithRelation, rule.OfType, warrantSpec.Context)
+		matchingWarrants, err := svc.getMatchingSubjectsWithSubjectType(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, rule.WithRelation, rule.OfType, warrantSpec.Context)
 		if err != nil {
 			return false, decisionPath, err
 		}
@@ -358,7 +410,7 @@ func (svc CheckService) Check(ctx context.Context, authInfo *service.AuthInfo, w
 	}
 
 	// Check against indirectly related warrants
-	matchingWarrants, err := svc.getMatchingSubjects(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, "%", warrantCheck.Context)
+	matchingWarrants, err := svc.getMatchingSubjects(ctx, warrantCheck.ObjectType, warrantCheck.ObjectId, warrantCheck.Relation, warrantCheck.Context)
 	if err != nil {
 		return false, decisionPath, err
 	}

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -411,7 +411,7 @@ func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context,
 	return models, nil
 }
 
-func (repo MySQLRepository) GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
+func (repo MySQLRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
 	err := repo.DB.SelectContext(

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -373,7 +373,7 @@ func (repo MySQLRepository) GetAllMatchingWildcard(ctx context.Context, objectTy
 	return models, nil
 }
 
-func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
+func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
 	err := repo.DB.SelectContext(
@@ -384,7 +384,45 @@ func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context,
 			FROM warrant
 			WHERE
 				objectType = ? AND
-				objectId = ? AND
+				(objectId = ? OR objectId = "*") AND
+				relation = ? AND
+				(contextHash = ? OR contextHash = "") AND
+				deletedAt IS NULL
+			ORDER BY createdAt DESC, id DESC
+		`,
+		objectType,
+		objectId,
+		relation,
+		contextHash,
+	)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return models, nil
+		default:
+			return nil, errors.Wrapf(err, "error getting warrants with object type %s, object id %s, and relation %s", objectType, objectId, relation)
+		}
+	}
+
+	for i := range warrants {
+		models = append(models, &warrants[i])
+	}
+
+	return models, nil
+}
+
+func (repo MySQLRepository) GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
+	models := make([]Model, 0)
+	warrants := make([]Warrant, 0)
+	err := repo.DB.SelectContext(
+		ctx,
+		&warrants,
+		`
+			SELECT id, objectType, objectId, relation, subjectType, subjectId, subjectRelation, contextHash, createdAt, updatedAt, deletedAt
+			FROM warrant
+			WHERE
+				objectType = ? AND
+				(objectId = ? OR objectId = "*") AND
 				relation = ? AND
 				subjectType = ? AND
 				(contextHash = ? OR contextHash = "") AND

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -318,61 +318,6 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 	return models, nil
 }
 
-func (repo MySQLRepository) GetAllMatchingWildcard(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error) {
-	models := make([]Model, 0)
-	warrants := make([]Warrant, 0)
-	err := repo.DB.SelectContext(
-		ctx,
-		&warrants,
-		`
-			SELECT
-				w2.id,
-				w2.objectType,
-				w2.objectId,
-				w2.relation,
-				w1.subjectType,
-				w1.subjectId,
-				w1.subjectRelation,
-				w2.contextHash,
-				w2.createdAt,
-				w2.updatedAt
-			FROM warrant AS w1
-			JOIN warrant AS w2 ON
-				w1.id != w2.id AND
-				w1.objectType = w2.objectType AND
-				w1.relation = w2.relation AND
-				w1.contextHash = w2.contextHash
-			WHERE
-				w1.objectType = ? AND
-				w1.objectId = "*" AND
-				w2.objectId = ? AND
-				w1.relation = ? AND
-				(w1.contextHash = ? OR w1.contextHash = "") AND
-				w1.deletedAt IS NULL AND
-				w2.deletedAt IS NULL
-			ORDER BY w2.createdAt DESC, w2.id DESC
-		`,
-		objectType,
-		objectId,
-		relation,
-		contextHash,
-	)
-	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			return models, nil
-		default:
-			return nil, errors.Wrapf(err, "error getting warrants matching object type %s and relation %s", objectType, relation)
-		}
-	}
-
-	for i := range warrants {
-		models = append(models, &warrants[i])
-	}
-
-	return models, nil
-}
-
 func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)

--- a/pkg/authz/warrant/postgres.go
+++ b/pkg/authz/warrant/postgres.go
@@ -411,7 +411,7 @@ func (repo PostgresRepository) GetAllMatchingObjectAndRelation(ctx context.Conte
 	return models, nil
 }
 
-func (repo PostgresRepository) GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
+func (repo PostgresRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
 	err := repo.DB.SelectContext(

--- a/pkg/authz/warrant/repository.go
+++ b/pkg/authz/warrant/repository.go
@@ -14,7 +14,8 @@ type WarrantRepository interface {
 	GetByID(ctx context.Context, id int64) (Model, error)
 	GetWithContextMatch(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, contextHash string) (Model, error)
 	GetAllMatchingWildcard(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
-	GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error)
+	GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
+	GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error)
 	List(ctx context.Context, filterOptions *FilterOptions, listParams service.ListParams) ([]Model, error)
 	DeleteById(ctx context.Context, id int64) error
 	DeleteAllByObject(ctx context.Context, objectType string, objectId string) error

--- a/pkg/authz/warrant/repository.go
+++ b/pkg/authz/warrant/repository.go
@@ -13,7 +13,6 @@ type WarrantRepository interface {
 	Get(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, contextHash string) (Model, error)
 	GetByID(ctx context.Context, id int64) (Model, error)
 	GetWithContextMatch(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, contextHash string) (Model, error)
-	GetAllMatchingWildcard(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
 	GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
 	GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error)
 	List(ctx context.Context, filterOptions *FilterOptions, listParams service.ListParams) ([]Model, error)

--- a/pkg/authz/warrant/repository.go
+++ b/pkg/authz/warrant/repository.go
@@ -15,7 +15,7 @@ type WarrantRepository interface {
 	GetWithContextMatch(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, contextHash string) (Model, error)
 	GetAllMatchingWildcard(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
 	GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error)
-	GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error)
+	GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error)
 	List(ctx context.Context, filterOptions *FilterOptions, listParams service.ListParams) ([]Model, error)
 	DeleteById(ctx context.Context, id int64) error
 	DeleteAllByObject(ctx context.Context, objectType string, objectId string) error

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -415,7 +415,7 @@ func (repo SQLiteRepository) GetAllMatchingObjectAndRelation(ctx context.Context
 	return models, nil
 }
 
-func (repo SQLiteRepository) GetAllMatchingObjectAndRelationWithSubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
+func (repo SQLiteRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
 	err := repo.DB.SelectContext(

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -322,61 +322,6 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 	return models, nil
 }
 
-func (repo SQLiteRepository) GetAllMatchingWildcard(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error) {
-	models := make([]Model, 0)
-	warrants := make([]Warrant, 0)
-	err := repo.DB.SelectContext(
-		ctx,
-		&warrants,
-		`
-			SELECT
-				w2.id,
-				w2.objectType,
-				w2.objectId,
-				w2.relation,
-				w1.subjectType,
-				w1.subjectId,
-				w1.subjectRelation,
-				w2.contextHash,
-				w2.createdAt,
-				w2.updatedAt
-			FROM warrant AS w1
-			JOIN warrant AS w2 ON
-				w1.id != w2.id AND
-				w1.objectType = w2.objectType AND
-				w1.relation = w2.relation AND
-				w1.contextHash = w2.contextHash
-			WHERE
-				w1.objectType = ? AND
-				w1.objectId = "*" AND
-				w2.objectId = ? AND
-				w1.relation = ? AND
-				(w1.contextHash = ? OR w1.contextHash = "") AND
-				w1.deletedAt IS NULL AND
-				w2.deletedAt IS NULL
-			ORDER BY w2.createdAt DESC, w2.id DESC
-		`,
-		objectType,
-		objectId,
-		relation,
-		contextHash,
-	)
-	if err != nil {
-		switch err {
-		case sql.ErrNoRows:
-			return models, nil
-		default:
-			return nil, errors.Wrapf(err, "error getting warrants matching object type %s and relation %s", objectType, relation)
-		}
-	}
-
-	for i := range warrants {
-		models = append(models, &warrants[i])
-	}
-
-	return models, nil
-}
-
 func (repo SQLiteRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string, contextHash string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)

--- a/tests/authz-wildcard.json
+++ b/tests/authz-wildcard.json
@@ -683,7 +683,7 @@
             }
         },
         {
-            "name": "checkUserCNotOwnerOfReportB",
+            "name": "checkUserCOwnerOfReportB",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -708,13 +708,13 @@
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "code": 403,
-                    "result": "Not Authorized"
+                    "code": 200,
+                    "result": "Authorized"
                 }
             }
         },
         {
-            "name": "checkUserDNotOwnerOfReportA",
+            "name": "checkUserDOwnerOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -739,8 +739,8 @@
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "code": 403,
-                    "result": "Not Authorized"
+                    "code": 200,
+                    "result": "Authorized"
                 }
             }
         },

--- a/tests/authz-wildcard2.json
+++ b/tests/authz-wildcard2.json
@@ -528,6 +528,34 @@
             }
         },
         {
+            "name": "checkUserExternalUser1IsViewerOfScheduleA1",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "schedule",
+                            "objectId": "schedule-A1",
+                            "relation": "viewer",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "external-user-1"
+                            }
+                        }
+                    ]
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "code": 200,
+                    "result": "Authorized"
+                }
+            }
+        },
+        {
             "name": "removeDepartmentA1ManagerFromUserDeptManagerA",
             "request": {
                 "method": "DELETE",

--- a/tests/authz-wildcard2.json
+++ b/tests/authz-wildcard2.json
@@ -1,0 +1,761 @@
+{
+    "ignoredFields": [
+        "createdAt"
+    ],
+    "tests": [
+        {
+            "name": "createObjectTypeDepartment",
+            "request": {
+                "method": "POST",
+                "url": "/v1/object-types",
+                "body": {
+                    "type": "department",
+                    "relations": {
+                        "manager": {
+                            "inheritIf": "manager",
+                            "ofType": "division",
+                            "withRelation": "parent"
+                        },
+                        "member": {
+                            "inheritIf": "manager"
+                        },
+                        "parent": {
+                            "inheritIf": "parent",
+                            "ofType": "division",
+                            "withRelation": "parent"
+                        }
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "department",
+                    "relations": {
+                        "manager": {
+                            "inheritIf": "manager",
+                            "ofType": "division",
+                            "withRelation": "parent"
+                        },
+                        "member": {
+                            "inheritIf": "manager"
+                        },
+                        "parent": {
+                            "inheritIf": "parent",
+                            "ofType": "division",
+                            "withRelation": "parent"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "name": "createObjectTypeDivision",
+            "request": {
+                "method": "POST",
+                "url": "/v1/object-types",
+                "body": {
+                    "type": "division",
+                    "relations": {
+                        "manager": {
+                            "inheritIf": "admin",
+                            "ofType": "organization",
+                            "withRelation": "parent"
+                        },
+                        "member": {
+                            "inheritIf": "manager"
+                        },
+                        "parent": {}
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "division",
+                    "relations": {
+                        "manager": {
+                            "inheritIf": "admin",
+                            "ofType": "organization",
+                            "withRelation": "parent"
+                        },
+                        "member": {
+                            "inheritIf": "manager"
+                        },
+                        "parent": {}
+                    }
+                }
+            }
+        },
+        {
+            "name": "createObjectTypeOrganization",
+            "request": {
+                "method": "POST",
+                "url": "/v1/object-types",
+                "body": {
+                    "type": "organization",
+                    "relations": {
+                        "admin": {},
+                        "member": {
+                            "inheritIf": "admin"
+                        }
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "organization",
+                    "relations": {
+                        "admin": {},
+                        "member": {
+                            "inheritIf": "admin"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "name": "createObjectTypeSchedule",
+            "request": {
+                "method": "POST",
+                "url": "/v1/object-types",
+                "body": {
+                    "type": "schedule",
+                    "relations": {
+                        "editor": {
+                            "inheritIf": "anyOf",
+                            "rules": [
+                                {
+                                    "inheritIf": "manager",
+                                    "ofType": "department",
+                                    "withRelation": "parent"
+                                },
+                                {
+                                    "inheritIf": "manager",
+                                    "ofType": "division",
+                                    "withRelation": "parent"
+                                },
+                                {
+                                    "inheritIf": "admin",
+                                    "ofType": "organization",
+                                    "withRelation": "parent"
+                                }
+                            ]
+                        },
+                        "parent": {
+                            "inheritIf": "parent",
+                            "ofType": "department",
+                            "withRelation": "parent"
+                        },
+                        "viewer": {
+                            "inheritIf": "editor"
+                        }
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "schedule",
+                    "relations": {
+                        "editor": {
+                            "inheritIf": "anyOf",
+                            "rules": [
+                                {
+                                    "inheritIf": "manager",
+                                    "ofType": "department",
+                                    "withRelation": "parent"
+                                },
+                                {
+                                    "inheritIf": "manager",
+                                    "ofType": "division",
+                                    "withRelation": "parent"
+                                },
+                                {
+                                    "inheritIf": "admin",
+                                    "ofType": "organization",
+                                    "withRelation": "parent"
+                                }
+                            ]
+                        },
+                        "parent": {
+                            "inheritIf": "parent",
+                            "ofType": "department",
+                            "withRelation": "parent"
+                        },
+                        "viewer": {
+                            "inheritIf": "editor"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignDepartmentA1ManagerToUserDeptManagerA",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-A"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignDepartmentA1ParentToDivisionDivA1",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "division",
+                        "objectId": "div-A1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "division",
+                        "objectId": "div-A1"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignDepartmentB1ManagerToUserDeptManagerB",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-B"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignOrganizationOrgAAsParentOfAnyDivision",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "*",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "organization",
+                        "objectId": "org-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "division",
+                    "objectId": "*",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "organization",
+                        "objectId": "org-A"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignDivisionDivA1ManagerToUserDivManagerA",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-A"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignDivisionDivB1ManagerToUserDivManagerB",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-B"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignOrganizationOrgAAdminToUserAdminA",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-A",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-A",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-A"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignOrganizationOrgBAdminToUserAdminB",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-B",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-B",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-B"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignScheduleScheduleA1ParentToDepartmentDeptA1",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "department",
+                        "objectId": "dept-A1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "department",
+                        "objectId": "dept-A1"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignScheduleScheduleA1ViewerToUserExternalUser1",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "viewer",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "external-user-1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "viewer",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "external-user-1"
+                    }
+                }
+            }
+        },
+        {
+            "name": "checkUserAdminAIsViewerOfScheduleA1",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "schedule",
+                            "objectId": "schedule-A1",
+                            "relation": "viewer",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "admin-A"
+                            }
+                        }
+                    ]
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "code": 200,
+                    "result": "Authorized"
+                }
+            }
+        },
+        {
+            "name": "checkUserAdminBIsNotViewerOfScheduleA1",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "schedule",
+                            "objectId": "schedule-A1",
+                            "relation": "viewer",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "admin-B"
+                            }
+                        }
+                    ]
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "code": 403,
+                    "result": "Not Authorized"
+                }
+            }
+        },
+        {
+            "name": "removeDepartmentA1ManagerFromUserDeptManagerA",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeDepartmentA1ParentFromDivisionDivA1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "division",
+                        "objectId": "div-A1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeDepartmentB1ManagerFromUserDeptManagerB",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "department",
+                    "objectId": "dept-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "dept-manager-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeOrganizationOrgAAsParentOfAnyDivision",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "*",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "organization",
+                        "objectId": "org-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeDivisionDivA1ManagerFromUserDivManagerA",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-A1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeDivisionDivB1ManagerFromUserDivManagerB",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "division",
+                    "objectId": "div-B1",
+                    "relation": "manager",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "div-manager-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeOrganizationOrgAAdminFromUserAdminA",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-A",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-A"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeOrganizationOrgBAdminFromUserAdminB",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "organization",
+                    "objectId": "org-B",
+                    "relation": "admin",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "admin-B"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeScheduleScheduleA1ParentFromDepartmentDeptA1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "parent",
+                    "subject": {
+                        "objectType": "department",
+                        "objectId": "dept-A1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeScheduleScheduleA1ViewerFromUserExternalUser1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "schedule",
+                    "objectId": "schedule-A1",
+                    "relation": "viewer",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "external-user-1"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectTypeSchedule",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/object-types/schedule"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectTypeOrganization",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/object-types/organization"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectTypeDivision",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/object-types/division"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectTypeDepartment",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/object-types/department"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        }
+    ]
+}

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -526,7 +526,7 @@
                             "subjectId": "user-e"
                         },
                         {
-                            "type": "access_denied",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-a",
@@ -628,7 +628,7 @@
                             "subjectId": "user-c"
                         },
                         {
-                            "type": "access_denied",
+                            "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
                             "objectId": "report-b",


### PR DESCRIPTION
Currently, **wildcards warrants are required to resolve to at least one existing warrant with an explicit `objectId` specified**. This approach was initially favored to provide additional protections / integrity (especially when dealing with context). However, in scenarios where wildcard warrants indirectly reference warrants having an explicit `objectId`, the wildcard warrant doesn't have a warrant (directly related to itself) to resolve to, so any dependent access checks incorrectly return an unauthorized response.

This PR does two things:
(1) Fixes the issue described above by allowing wildcard `objectId`s in warrants to resolve to **any** `objectId` rather than looking to resolve them to an existing `objectId` (with matching context). This approach no longer provides protections / integrity on the actual `objectId` being resolved to because that additional check is seen as something the user should either (1) create a separate warrant to enforce or (2) enforce within their own database/application.
(2) Fixes a bug in the access check method that was incorrectly fetching indirect warrants to expand the search upon.
