### PR TITLE
Return debug info in all authorized scenarios + add authz tests for indirect warrants

### DIFF
--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -321,6 +321,13 @@ func (svc CheckService) CheckMany(ctx context.Context, authInfo *service.AuthInf
 		return nil, err
 	}
 
+	if warrantCheck.Debug {
+		checkResult.ProcessingTime = time.Since(start).Milliseconds()
+		if len(decisionPath) > 0 {
+			checkResult.DecisionPath[warrantSpec.String()] = decisionPath
+		}
+	}
+
 	if match {
 		err = svc.EventSvc.TrackAccessAllowedEvent(ctx, warrantSpec.ObjectType, warrantSpec.ObjectId, warrantSpec.Relation, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId, warrantSpec.Subject.Relation, warrantSpec.Context)
 		if err != nil {
@@ -339,13 +346,6 @@ func (svc CheckService) CheckMany(ctx context.Context, authInfo *service.AuthInf
 
 	checkResult.Code = http.StatusForbidden
 	checkResult.Result = NotAuthorized
-	if warrantCheck.Debug {
-		checkResult.ProcessingTime = time.Since(start).Milliseconds()
-		if len(decisionPath) > 0 {
-			checkResult.DecisionPath[warrantSpec.String()] = decisionPath
-		}
-	}
-
 	return &checkResult, nil
 }
 

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -95,6 +95,24 @@
             }
         },
         {
+            "name": "createUserUserb",
+            "request": {
+                "method": "POST",
+                "url": "/v1/users",
+                "body": {
+                    "userId": "user-b",
+                    "email": "user-b@warrant.dev"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "userId": "user-b",
+                    "email": "user-b@warrant.dev"
+                }
+            }
+        },
+        {
             "name": "assignUserAEditorOfReportA",
             "request": {
                 "method": "POST",
@@ -118,6 +136,56 @@
                     "subject": {
                         "objectType": "user",
                         "objectId": "user-a"
+                    }
+                }
+            }
+        },
+        {
+            "name": "createRoleAdmin",
+            "request": {
+                "method": "POST",
+                "url": "/v1/roles",
+                "body": {
+                    "roleId": "admin",
+                    "name": "Admin",
+                    "description": "Grants access to view and edit report-a."
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "roleId": "admin",
+                    "name": "Admin",
+                    "description": "Grants access to view and edit report-a."
+                }
+            }
+        },
+        {
+            "name": "assignMemberOfRoleAdminEditorOfReportA",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "report",
+                    "objectId": "report-a",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin",
+                        "relation": "member"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "report",
+                    "objectId": "report-a",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin",
+                        "relation": "member"
                     }
                 }
             }
@@ -239,6 +307,40 @@
             }
         },
         {
+            "name": "assignRoleAdminToUserBInTenantB",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-b"
+                    },
+                    "context": {
+                        "tenant": "tenant-b"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-b"
+                    },
+                    "context": {
+                        "tenant": "tenant-b"
+                    }
+                }
+            }
+        },
+        {
             "name": "assignRoleSeniorAccountantToUserAInTenantA",
             "request": {
                 "method": "POST",
@@ -268,6 +370,102 @@
                     },
                     "context": {
                         "tenant": "tenant-a"
+                    }
+                }
+            }
+        },
+        {
+            "name": "checkUserBEditorOfReportAInTenantB",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "user-b"
+                            },
+                            "context": {
+                                "tenant": "tenant-b"
+                            }
+                        }
+                    ],
+                    "debug": true
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "code": 200,
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "report:report-a#editor@user:user-b[tenant=tenant-b]": [
+                            {
+                                "objectType": "role",
+                                "objectId": "admin",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-b"
+                                },
+                                "context": {
+                                    "tenant": "tenant-b"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "name": "checkUserBViewerOfReportAInTenantB",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "user-b"
+                            },
+                            "context": {
+                                "tenant": "tenant-b"
+                            }
+                        }
+                    ],
+                    "debug": true
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "code": 200,
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "report:report-a#editor@user:user-b[tenant=tenant-b]": [
+                            {
+                                "objectType": "role",
+                                "objectId": "admin",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-b"
+                                },
+                                "context": {
+                                    "tenant": "tenant-b"
+                                }
+                            }
+                        ]
                     }
                 }
             }
@@ -609,6 +807,36 @@
             }
         },
         {
+            "name": "removeMemberOfRoleAdminEditorOfReportA",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "report",
+                    "objectId": "report-a",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin",
+                        "relation": "member"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleAdmin",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/roles/admin"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
             "name": "removeUserAEditorOfReportA",
             "request": {
                 "method": "DELETE",
@@ -622,6 +850,16 @@
                         "objectId": "user-a"
                     }
                 }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUserUserb",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/users/user-b"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -1,6 +1,7 @@
 {
     "ignoredFields": [
-        "createdAt"
+        "createdAt",
+        "processingTime"
     ],
     "tests": [
         {
@@ -94,7 +95,7 @@
             }
         },
         {
-            "name": "createWarrant",
+            "name": "assignUserAEditorOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v1/warrants",
@@ -238,7 +239,7 @@
             }
         },
         {
-            "name": "assignRoleSeniorAccountantToUserWithContext",
+            "name": "assignRoleSeniorAccountantToUserAInTenantA",
             "request": {
                 "method": "POST",
                 "url": "/v1/warrants",
@@ -272,7 +273,7 @@
             }
         },
         {
-            "name": "checkAccessWithContextAuthorized",
+            "name": "checkUserAMemberOfPermissionEditBalanceSheetInTenantA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -291,19 +292,36 @@
                                 "tenant": "tenant-a"
                             }
                         }
-                    ]
+                    ],
+                    "debug": true
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "code": 200,
-                    "result": "Authorized"
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "permission:edit-balance-sheet#member@user:user-a[tenant=tenant-a]": [
+                            {
+                                "objectType": "role",
+                                "objectId": "senior-accountant",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-a"
+                                },
+                                "context": {
+                                    "tenant": "tenant-a"
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         },
         {
-            "name": "checkAccessWithContextNotAuthorized",
+            "name": "checkUserANotMemberOfPermissionEditBalanceSheetInTenantB",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -322,7 +340,8 @@
                                 "tenant": "tenant-b"
                             }
                         }
-                    ]
+                    ],
+                    "debug": true
                 }
             },
             "expectedResponse": {
@@ -334,7 +353,7 @@
             }
         },
         {
-            "name": "checkAccessDirectWarrantAuthorized",
+            "name": "checkUserAEditorOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -350,19 +369,33 @@
                                 "objectId": "user-a"
                             }
                         }
-                    ]
+                    ],
+                    "debug": true
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "code": 200,
-                    "result": "Authorized"
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "report:report-a#editor@user:user-a": [
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-a"
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         },
         {
-            "name": "checkAccessUsersetRuleAuthorized",
+            "name": "checkUserAViewerOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -378,19 +411,33 @@
                                 "objectId": "user-a"
                             }
                         }
-                    ]
+                    ],
+                    "debug": true
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "code": 200,
-                    "result": "Authorized"
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "report:report-a#viewer@user:user-a": [
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-a"
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         },
         {
-            "name": "checkAccessAllOfRuleAuthorized",
+            "name": "checkUserAEditorViewerOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -406,19 +453,42 @@
                                 "objectId": "user-a"
                             }
                         }
-                    ]
+                    ],
+                    "debug": true
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "code": 200,
-                    "result": "Authorized"
+                    "result": "Authorized",
+                    "decisionPath": {
+                        "report:report-a#editor-viewer@user:user-a": [
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-a"
+                                }
+                            },
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "user-a"
+                                }
+                            }
+                        ]
+                    }
                 }
             }
         },
         {
-            "name": "checkAccessNoneOfRuleAuthorized",
+            "name": "checkUserANonOwnerOfReportA",
             "request": {
                 "method": "POST",
                 "url": "/v2/authorize",
@@ -539,7 +609,7 @@
             }
         },
         {
-            "name": "deleteWarrant",
+            "name": "removeUserAEditorOfReportA",
             "request": {
                 "method": "DELETE",
                 "url": "/v1/warrants",

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -180,28 +180,12 @@
             "name": "listResourceEventsFilterByResourceTypeAndResourceId",
             "request": {
                 "method": "GET",
-                "url": "/v1/resource-events?limit=5&resourceType=user&resourceId=user-a"
+                "url": "/v1/resource-events?limit=3&resourceType=user&resourceId=user-a"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "events": [
-                        {
-                            "type": "deleted",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-a"
-                        },
-                        {
-                            "type": "created",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-a",
-                            "meta": {
-                                "email": "user-a@warrant.dev",
-                                "userId": "user-a"
-                            }
-                        },
                         {
                             "type": "deleted",
                             "source": "api",

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -388,6 +388,16 @@
                             "subjectId": "user-a"
                         },
                         {
+                            "type": "access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "role",
+                            "subjectId": "admin",
+                            "subjectRelation": "member"
+                        },
+                        {
                             "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
@@ -411,15 +421,6 @@
                             "objectType": "report",
                             "objectId": "report-a",
                             "relation": "viewer",
-                            "subjectType": "user",
-                            "subjectId": "user-a"
-                        },
-                        {
-                            "type": "access_allowed",
-                            "source": "api",
-                            "objectType": "report",
-                            "objectId": "report-a",
-                            "relation": "editor",
                             "subjectType": "user",
                             "subjectId": "user-a"
                         }
@@ -448,6 +449,16 @@
                             "subjectId": "user-a"
                         },
                         {
+                            "type": "access_revoked",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "role",
+                            "subjectId": "admin",
+                            "subjectRelation": "member"
+                        },
+                        {
                             "type": "access_allowed",
                             "source": "api",
                             "objectType": "report",
@@ -471,15 +482,6 @@
                             "objectType": "report",
                             "objectId": "report-a",
                             "relation": "viewer",
-                            "subjectType": "user",
-                            "subjectId": "user-a"
-                        },
-                        {
-                            "type": "access_allowed",
-                            "source": "api",
-                            "objectType": "report",
-                            "objectId": "report-a",
-                            "relation": "editor",
                             "subjectType": "user",
                             "subjectId": "user-a"
                         }
@@ -655,6 +657,26 @@
                             "type": "access_revoked",
                             "source": "api",
                             "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "role",
+                            "subjectId": "admin",
+                            "subjectRelation": "member"
+                        },
+                        {
+                            "type": "access_granted",
+                            "source": "api",
+                            "objectType": "report",
+                            "objectId": "report-a",
+                            "relation": "editor",
+                            "subjectType": "role",
+                            "subjectId": "admin",
+                            "subjectRelation": "member"
+                        },
+                        {
+                            "type": "access_revoked",
+                            "source": "api",
+                            "objectType": "report",
                             "objectId": "*",
                             "relation": "owner",
                             "subjectType": "role",
@@ -669,26 +691,6 @@
                             "relation": "owner",
                             "subjectType": "role",
                             "subjectId": "admin-b",
-                            "subjectRelation": "member"
-                        },
-                        {
-                            "type": "access_granted",
-                            "source": "api",
-                            "objectType": "report",
-                            "objectId": "*",
-                            "relation": "owner",
-                            "subjectType": "role",
-                            "subjectId": "admin-b",
-                            "subjectRelation": "member"
-                        },
-                        {
-                            "type": "access_granted",
-                            "source": "api",
-                            "objectType": "report",
-                            "objectId": "*",
-                            "relation": "owner",
-                            "subjectType": "role",
-                            "subjectId": "admin-a",
                             "subjectRelation": "member"
                         }
                     ],


### PR DESCRIPTION
Currently, the authorize endpoint doesn't return the debug info in some scenarios. This PR ensures that the debug info is always returned when requested. The PR also adds some additional test scenarios covering the usage of [indirect warrants](https://docs.warrant.dev/concepts/warrants/#indirect-warrants).