### PR TITLE
Include matching warrant in decisionPath for authz checks

### DIFF
--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -207,6 +207,7 @@ func (svc CheckService) checkRule(ctx context.Context, authInfo *service.AuthInf
 			}
 
 			if match {
+				decisionPath = append(decisionPath, matchingWarrant)
 				return true, decisionPath, nil
 			}
 		}
@@ -402,6 +403,7 @@ func (svc CheckService) Check(ctx context.Context, authInfo *service.AuthInfo, w
 		}
 
 		if match {
+			decisionPath = append(decisionPath, matchingWarrant)
 			return true, decisionPath, nil
 		}
 	}

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -416,6 +416,16 @@
                                 "context": {
                                     "tenant": "tenant-b"
                                 }
+                            },
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "admin",
+                                    "relation": "member"
+                                }
                             }
                         ]
                     }
@@ -464,6 +474,16 @@
                                 "context": {
                                     "tenant": "tenant-b"
                                 }
+                            },
+                            {
+                                "objectType": "report",
+                                "objectId": "report-a",
+                                "relation": "editor",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "admin",
+                                    "relation": "member"
+                                }
                             }
                         ]
                     }
@@ -511,6 +531,15 @@
                                 },
                                 "context": {
                                     "tenant": "tenant-a"
+                                }
+                            },
+                            {
+                                "objectType": "permission",
+                                "objectId": "edit-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "senior-accountant"
                                 }
                             }
                         ]


### PR DESCRIPTION
This PR updates the Check method and its related methods to include the warrant that leads to an Authorized result for a warrant check.

Consider the following scenario:
- User `1` is a member of role `admin`
- Role `admin` is a member of permission `edit-items`

If we do the following check: Is user `1` a member of permission `edit-items`? We would only get the following warrant returned as part of the decision path: `user 1 is a member of role admin`.

With the proposed changes, the decision path would now include the complete path:
```
- User `1` is a member of role `admin`
- Role `admin` is a member of permission `edit-items`
```