### PR TITLE
Update usages of `fmt.Errorf` to `errors.New` where applicable

### DIFF
--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 	check "github.com/warrant-dev/warrant/pkg/authz/check"
 	feature "github.com/warrant-dev/warrant/pkg/authz/feature"
@@ -104,7 +105,7 @@ func (env *ServiceEnv) InitDB(cfg config.Config) error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid database configuration provided")
+	return errors.New("invalid database configuration provided")
 }
 
 func (env *ServiceEnv) InitEventDB(config config.Config) error {
@@ -165,7 +166,7 @@ func (env *ServiceEnv) InitEventDB(config config.Config) error {
 		return nil
 	}
 
-	return fmt.Errorf("invalid database configuration provided")
+	return errors.New("invalid database configuration provided")
 }
 
 func NewServiceEnv() ServiceEnv {

--- a/pkg/authz/feature/repository.go
+++ b/pkg/authz/feature/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (FeatureRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/object/repository.go
+++ b/pkg/authz/object/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -21,25 +22,25 @@ func NewRepository(db database.Database) (ObjectRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/objecttype/repository.go
+++ b/pkg/authz/objecttype/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (ObjectTypeRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/permission/repository.go
+++ b/pkg/authz/permission/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (PermissionRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/pricingtier/repository.go
+++ b/pkg/authz/pricingtier/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (PricingTierRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/role/repository.go
+++ b/pkg/authz/role/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (RoleRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/tenant/repository.go
+++ b/pkg/authz/tenant/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (TenantRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/user/repository.go
+++ b/pkg/authz/user/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -22,25 +23,25 @@ func NewRepository(db database.Database) (UserRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/warrant/repository.go
+++ b/pkg/authz/warrant/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -26,25 +27,25 @@ func NewRepository(db database.Database) (WarrantRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/authz/warrant/spec.go
+++ b/pkg/authz/warrant/spec.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pkg/errors"
 	context "github.com/warrant-dev/warrant/pkg/context"
 )
 
@@ -45,7 +46,7 @@ func StringToSubjectSpec(str string) (*SubjectSpec, error) {
 		objectType, objectId, colonFound := strings.Cut(str, ":")
 
 		if !colonFound {
-			return nil, fmt.Errorf("invalid subject")
+			return nil, errors.New("invalid subject")
 		}
 
 		return &SubjectSpec{
@@ -59,7 +60,7 @@ func StringToSubjectSpec(str string) (*SubjectSpec, error) {
 
 	objectType, objectId, colonFound := strings.Cut(object, ":")
 	if !colonFound {
-		return nil, fmt.Errorf("invalid subject")
+		return nil, errors.New("invalid subject")
 	}
 
 	subjectSpec := &SubjectSpec{

--- a/pkg/database/sqlite-stub.go
+++ b/pkg/database/sqlite-stub.go
@@ -5,8 +5,8 @@ package database
 
 import (
 	"context"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/config"
 )
 
@@ -24,13 +24,13 @@ func (ds SQLite) Type() string {
 }
 
 func (ds *SQLite) Connect(ctx context.Context) error {
-	return fmt.Errorf("sqlite not supported")
+	return errors.New("sqlite not supported")
 }
 
 func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
-	return fmt.Errorf("sqlite not supported")
+	return errors.New("sqlite not supported")
 }
 
 func (ds SQLite) Ping(ctx context.Context) error {
-	return fmt.Errorf("sqlite not supported")
+	return errors.New("sqlite not supported")
 }

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -41,7 +41,7 @@ func (ds *SQLite) Connect(ctx context.Context) error {
 	var err error
 
 	if ds.Config.Database == ":memory:" {
-		return fmt.Errorf("invalid database \"%s\" provided for sqlite", ds.Config.Database)
+		return errors.New(fmt.Sprintf("invalid database \"%s\" provided for sqlite", ds.Config.Database))
 	}
 
 	connectionString := fmt.Sprintf("file:%s?_foreign_keys=on", url.QueryEscape(ds.Config.Database))

--- a/pkg/event/repository.go
+++ b/pkg/event/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 )
 
@@ -21,25 +22,25 @@ func NewRepository(db database.Database) (EventRepository, error) {
 	case database.TypeMySQL:
 		mysql, ok := db.(*database.MySQL)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeMySQL)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeMySQL))
 		}
 
 		return NewMySQLRepository(mysql), nil
 	case database.TypePostgres:
 		postgres, ok := db.(*database.Postgres)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypePostgres)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypePostgres))
 		}
 
 		return NewPostgresRepository(postgres), nil
 	case database.TypeSQLite:
 		sqlite, ok := db.(*database.SQLite)
 		if !ok {
-			return nil, fmt.Errorf("invalid %s database config", database.TypeSQLite)
+			return nil, errors.New(fmt.Sprintf("invalid %s database config", database.TypeSQLite))
 		}
 
 		return NewSQLiteRepository(sqlite), nil
 	default:
-		return nil, fmt.Errorf("unsupported database type %s specified", db.Type())
+		return nil, errors.New(fmt.Sprintf("unsupported database type %s specified", db.Type()))
 	}
 }

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -39,7 +39,7 @@ type AuthMiddlewareFunc func(config config.Config, next http.Handler) (http.Hand
 func ApiKeyAuthMiddleware(cfg config.Config, next http.Handler) (http.Handler, error) {
 	warrantCfg, ok := cfg.(config.WarrantConfig)
 	if !ok {
-		return nil, fmt.Errorf("cfg parameter on DefaultAuthMiddleware must be a WarrantConfig")
+		return nil, errors.New("cfg parameter on DefaultAuthMiddleware must be a WarrantConfig")
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ func ApiKeyAuthMiddleware(cfg config.Config, next http.Handler) (http.Handler, e
 func ApiKeyAndSessionAuthMiddleware(cfg config.Config, next http.Handler) (http.Handler, error) {
 	warrantCfg, ok := cfg.(config.WarrantConfig)
 	if !ok {
-		return nil, fmt.Errorf("cfg parameter on DefaultAuthMiddleware must be a WarrantConfig")
+		return nil, errors.New("cfg parameter on DefaultAuthMiddleware must be a WarrantConfig")
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Describe your changes
This PR updates all usages of `fmt.Errorf` to use `errors.New` (for new errors) or `errors.Wrap` (for instances where an already existing error is being bubbled up) instead. `errors.New` saves the stack trace at the current point which is useful for debugging and `errors.Wrap` ensures that we don't swallow a legitimate error. 

## Issue number and link (if applicable)
N/A