### PR TITLE
Add ability to define a readReplica dbpool for mysql

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,13 +79,16 @@ type DatastoreConfig struct {
 }
 
 type MySQLConfig struct {
-	Username           string `mapstructure:"username"`
-	Password           string `mapstructure:"password"`
-	Hostname           string `mapstructure:"hostname"`
-	Database           string `mapstructure:"database"`
-	MigrationSource    string `mapstructure:"migrationSource"`
-	MaxIdleConnections int    `mapstructure:"maxIdleConnections"`
-	MaxOpenConnections int    `mapstructure:"maxOpenConnections"`
+	Username                      string `mapstructure:"username"`
+	Password                      string `mapstructure:"password"`
+	Hostname                      string `mapstructure:"hostname"`
+	Database                      string `mapstructure:"database"`
+	MigrationSource               string `mapstructure:"migrationSource"`
+	MaxIdleConnections            int    `mapstructure:"maxIdleConnections"`
+	MaxOpenConnections            int    `mapstructure:"maxOpenConnections"`
+	ReadReplicaHostname           string `mapstructure:"readReplicaHostname"`
+	ReadReplicaMaxIdleConnections int    `mapstructure:"readReplicaMaxIdleConnections"`
+	ReadReplicaMaxOpenConnections int    `mapstructure:"readReplicaMaxOpenConnections"`
 }
 
 type PostgresConfig struct {


### PR DESCRIPTION
## Describe your changes

Proposal: Add a separate 'readReplica' endpoint (and respective max/idle conns) config to mysql allowing per request selection of dbpool (not yet implemented)

## Issue number and link (if applicable)
