### PR TITLE
Use contextual loggers + add reqStats object

### DIFF
--- a/pkg/authz/check/service.go
+++ b/pkg/authz/check/service.go
@@ -53,7 +53,7 @@ func (svc CheckService) getWithPolicyMatch(ctx context.Context, spec CheckWarran
 }
 
 func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType string, objectId string, relation string, checkCtx warrant.PolicyContext) ([]warrant.WarrantSpec, error) {
-	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@___%s", objectType, objectId, relation, checkCtx)
+	log.Ctx(ctx).Debug().Msgf("Getting matching subjects for %s:%s#%s@___%s", objectType, objectId, relation, checkCtx)
 
 	warrantSpecs := make([]warrant.WarrantSpec, 0)
 	objectTypeSpec, err := svc.ObjectTypeSvc.GetByTypeId(ctx, objectType)
@@ -93,7 +93,7 @@ func (svc CheckService) getMatchingSubjects(ctx context.Context, objectType stri
 }
 
 func (svc CheckService) getMatchingSubjectsBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string, checkCtx warrant.PolicyContext) ([]warrant.WarrantSpec, error) {
-	log.Debug().Msgf("Getting matching subjects for %s:%s#%s@%s:___%s", objectType, objectId, relation, subjectType, checkCtx)
+	log.Ctx(ctx).Debug().Msgf("Getting matching subjects for %s:%s#%s@%s:___%s", objectType, objectId, relation, subjectType, checkCtx)
 
 	warrantSpecs := make([]warrant.WarrantSpec, 0)
 	objectTypeSpec, err := svc.ObjectTypeSvc.GetByTypeId(ctx, objectType)
@@ -380,7 +380,7 @@ func (svc CheckService) CheckMany(ctx context.Context, authInfo *service.AuthInf
 
 // Check returns true if the subject has a warrant (explicitly or implicitly) for given objectType:objectId#relation and context
 func (svc CheckService) Check(ctx context.Context, authInfo *service.AuthInfo, warrantCheck CheckSpec) (match bool, decisionPath []warrant.WarrantSpec, err error) {
-	log.Debug().Msgf("Checking for warrant %s", warrantCheck.String())
+	log.Ctx(ctx).Debug().Msgf("Checking for warrant %s", warrantCheck.String())
 
 	// Used to automatically append tenant context for session token w/ tenantId checks
 	if authInfo != nil && authInfo.TenantId != "" {

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -27,7 +27,7 @@ type SQLite struct {
 
 func NewSQLite(config config.SQLiteConfig) *SQLite {
 	return &SQLite{
-		SQL:    NewSQL(nil, config.Database),
+		SQL:    NewSQL(nil, "localhost", config.Database),
 		Config: config,
 	}
 }
@@ -71,12 +71,12 @@ func (ds *SQLite) Connect(ctx context.Context) error {
 	db.Mapper = reflectx.NewMapperFunc("sqlite", func(s string) string { return s })
 
 	ds.DB = db
-	log.Debug().Msgf("Connected to sqlite database %s", ds.Config.Database)
+	log.Ctx(ctx).Debug().Msgf("Connected to sqlite database %s", ds.Config.Database)
 	return nil
 }
 
 func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
-	log.Debug().Msgf("Migrating sqlite database %s", ds.Config.Database)
+	log.Ctx(ctx).Debug().Msgf("Migrating sqlite database %s", ds.Config.Database)
 	// migrate database to latest schema
 	instance, err := sqlite3.WithInstance(ds.DB.DB, &sqlite3.Config{})
 	if err != nil {
@@ -102,18 +102,18 @@ func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
 	}
 
 	if currentVersion == toVersion {
-		log.Debug().Msg("Migrations already up-to-date")
+		log.Ctx(ctx).Debug().Msg("Migrations already up-to-date")
 		return nil
 	}
 
 	numStepsToMigrate := toVersion - currentVersion
-	log.Debug().Msgf("Applying %d migration(s)", numStepsToMigrate)
+	log.Ctx(ctx).Debug().Msgf("Applying %d migration(s)", numStepsToMigrate)
 	err = mig.Steps(int(numStepsToMigrate))
 	if err != nil {
 		return errors.Wrap(err, "Error migrating sqlite database")
 	}
 
-	log.Debug().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
+	log.Ctx(ctx).Debug().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
 	return nil
 }
 

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -90,12 +90,12 @@ func (svc EventService) TrackResourceEvent(ctx context.Context, resourceEventSpe
 		go func() {
 			resourceEvent, err := resourceEventSpec.ToResourceEvent()
 			if err != nil {
-				log.Err(err).Msgf("Error tracking resource event %s", resourceEventSpec.Type)
+				log.Ctx(ctx).Err(err).Msgf("Error tracking resource event %s", resourceEventSpec.Type)
 			}
 
 			err = svc.Repository.TrackResourceEvent(eventCtx, *resourceEvent)
 			if err != nil {
-				log.Err(err).Msgf("Error tracking resource event %s", resourceEvent.Type)
+				log.Ctx(ctx).Err(err).Msgf("Error tracking resource event %s", resourceEvent.Type)
 			}
 		}()
 		return nil
@@ -121,7 +121,7 @@ func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSp
 			for _, resourceEventSpec := range resourceEventSpecs {
 				resourceEvent, err := resourceEventSpec.ToResourceEvent()
 				if err != nil {
-					log.Err(err).Msgf("Error tracking resource events")
+					log.Ctx(ctx).Err(err).Msgf("Error tracking resource events")
 				}
 
 				resourceEvents = append(resourceEvents, *resourceEvent)
@@ -129,7 +129,7 @@ func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSp
 
 			err := svc.Repository.TrackResourceEvents(eventCtx, resourceEvents)
 			if err != nil {
-				log.Err(err).Msgf("Error tracking resource events")
+				log.Ctx(ctx).Err(err).Msgf("Error tracking resource events")
 			}
 		}()
 		return nil
@@ -233,12 +233,12 @@ func (svc EventService) TrackAccessEvent(ctx context.Context, accessEventSpec Cr
 		go func() {
 			accessEvent, err := accessEventSpec.ToAccessEvent()
 			if err != nil {
-				log.Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
+				log.Ctx(ctx).Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
 			}
 
 			err = svc.Repository.TrackAccessEvent(eventCtx, *accessEvent)
 			if err != nil {
-				log.Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
+				log.Ctx(ctx).Err(err).Msgf("Error tracking access event %s", accessEvent.Type)
 			}
 		}()
 		return nil
@@ -264,7 +264,7 @@ func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs 
 			for _, accessEventSpec := range accessEventSpecs {
 				accessEvent, err := accessEventSpec.ToAccessEvent()
 				if err != nil {
-					log.Err(err).Msg("Error tracking access events")
+					log.Ctx(ctx).Err(err).Msg("Error tracking access events")
 				}
 
 				accessEvents = append(accessEvents, *accessEvent)
@@ -272,7 +272,7 @@ func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs 
 
 			err := svc.Repository.TrackAccessEvents(eventCtx, accessEvents)
 			if err != nil {
-				log.Err(err).Msg("Error tracking access events")
+				log.Ctx(ctx).Err(err).Msg("Error tracking access events")
 			}
 		}()
 		return nil

--- a/pkg/service/middleware.go
+++ b/pkg/service/middleware.go
@@ -262,22 +262,22 @@ func ListMiddleware[T ListParamParser](next http.Handler) http.Handler {
 func GetListParamsFromContext(context context.Context) ListParams {
 	contextPage := context.Value(contextKeyPage)
 	if contextPage == nil {
-		log.Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
+		log.Ctx(context).Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
 	}
 
 	contextLimit := context.Value(contextKeyLimit)
 	if contextLimit == nil {
-		log.Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
+		log.Ctx(context).Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
 	}
 
 	contextSortBy := context.Value(contextKeySortBy)
 	if contextSortBy == nil {
-		log.Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
+		log.Ctx(context).Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
 	}
 
 	contextSortOrder := context.Value(contextKeySortOrder)
 	if contextSortOrder == nil {
-		log.Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
+		log.Ctx(context).Fatal().Msg("List context not available. Did you forget to add ListMiddleware to a handler?")
 	}
 
 	contextQuery := context.Value(contextKeyQuery)

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -1,0 +1,38 @@
+package stats
+
+import (
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+type RequestStatsKey struct{}
+
+type QueryStat struct {
+	Store     string
+	QueryType string
+	Duration  time.Duration
+}
+
+func (q QueryStat) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("store", q.Store).Str("type", q.QueryType).Dur("duration", q.Duration)
+}
+
+type RequestStats struct {
+	NumQueries int
+	Queries    []QueryStat
+}
+
+func (s *RequestStats) RecordQuery(stat QueryStat) {
+	s.Queries = append(s.Queries, stat)
+	s.NumQueries++
+}
+
+func (s *RequestStats) MarshalZerologObject(e *zerolog.Event) {
+	e.Int("numQueries", s.NumQueries)
+	arr := zerolog.Arr()
+	for _, query := range s.Queries {
+		arr.Object(query)
+	}
+	e.Array("queries", arr)
+}


### PR DESCRIPTION
## Describe your changes
- Use hlog.FromContext() logger wherever possible (to preserve context in logs)
- Create a request-level stats obj that can be logged for debugging:

```
1:16PM INF ACCESS clientIp=[ duration=6.689708 method=POST numQueries=4 protocol=HTTP/1.1 requestId=ci52001hct9nfn1tpic0 requestStats={"numQueries":4,"queries":[{"duration":0.000042,"queryType":"sql.read.Select","store":"127.0.0.1/warrantOSS"},{"duration":0.000042,"queryType":"sql.read.GetContext","store":"127.0.0.1/warrantOSS"},{"duration":0.000042,"queryType":"sql.read.Select","store":"127.0.0.1/warrantOSS"},{"duration":0.000042,"queryType":"sql.write.NamedExec","store":"127.0.0.1/warrantOSSEvents"}]} size=39 statusCode=200 uri=/v2/authorize userAgent=Go-http-client/1.1
```

## Issue number and link (if applicable)

N/A