### PR TITLE
Make the create and delete warrant endpoints backward compatible with context

### DIFF
--- a/pkg/authz/warrant/warrant.go
+++ b/pkg/authz/warrant/warrant.go
@@ -9,12 +9,13 @@ import (
 )
 
 type WarrantSpec struct {
-	ObjectType string       `json:"objectType" validate:"required,valid_object_type"`
-	ObjectId   string       `json:"objectId" validate:"required,valid_object_id"`
-	Relation   string       `json:"relation" validate:"required,valid_relation"`
-	Subject    *SubjectSpec `json:"subject" validate:"required"`
-	Policy     Policy       `json:"policy,omitempty"`
-	CreatedAt  time.Time    `json:"createdAt"`
+	ObjectType string            `json:"objectType" validate:"required,valid_object_type"`
+	ObjectId   string            `json:"objectId" validate:"required,valid_object_id"`
+	Relation   string            `json:"relation" validate:"required,valid_relation"`
+	Subject    *SubjectSpec      `json:"subject" validate:"required"`
+	Context    map[string]string `json:"context,omitempty" validate:"excluded_with=Policy"`
+	Policy     Policy            `json:"policy,omitempty" validate:"excluded_with=Context"`
+	CreatedAt  time.Time         `json:"createdAt"`
 }
 
 func (spec *WarrantSpec) ToWarrant() (*Warrant, error) {
@@ -28,6 +29,18 @@ func (spec *WarrantSpec) ToWarrant() (*Warrant, error) {
 		warrant.SubjectType = spec.Subject.ObjectType
 		warrant.SubjectId = spec.Subject.ObjectId
 		warrant.SubjectRelation = spec.Subject.Relation
+	}
+
+	// NOTE: To preserve backwards compatibility of the create
+	// warrant API with the introduction of attaching policies
+	// to warrants, warrants can still be created with context,
+	// and the context will be converted into a policy.
+	if spec.Context != nil {
+		policyClauses := make([]string, 0)
+		for k, v := range spec.Context {
+			policyClauses = append(policyClauses, fmt.Sprintf(`%s == "%s"`, k, v))
+		}
+		spec.Policy = Policy(strings.Join(policyClauses, " && "))
 	}
 
 	if spec.Policy != "" {

--- a/pkg/authz/warrant/warrant_test.go
+++ b/pkg/authz/warrant/warrant_test.go
@@ -36,6 +36,7 @@ func TestToWarrantDirectWarrantSpec(t *testing.T) {
 }
 
 func TestToWarrantDirectWarrantSpecWithPolicy(t *testing.T) {
+	policy := Policy("tenant == 101")
 	spec := WarrantSpec{
 		ObjectType: "permission",
 		ObjectId:   "test",
@@ -44,7 +45,7 @@ func TestToWarrantDirectWarrantSpecWithPolicy(t *testing.T) {
 			ObjectType: "user",
 			ObjectId:   "user-A",
 		},
-		Policy: Policy("tenant == 101"),
+		Policy: policy,
 	}
 	expectedWarrant := &Warrant{
 		ObjectType:  "permission",
@@ -52,8 +53,41 @@ func TestToWarrantDirectWarrantSpecWithPolicy(t *testing.T) {
 		Relation:    "member",
 		SubjectType: "user",
 		SubjectId:   "user-A",
-		Policy:      spec.Policy,
-		PolicyHash:  spec.Policy.Hash(),
+		Policy:      policy,
+		PolicyHash:  policy.Hash(),
+	}
+	actualWarrant, err := spec.ToWarrant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cmp.Equal(actualWarrant, expectedWarrant) {
+		t.Fatalf("Expected warrant to be %v, but it was %v", expectedWarrant, actualWarrant)
+	}
+}
+
+func TestToWarrantDirectWarrantSpecWithContext(t *testing.T) {
+	policy := Policy(`tenant == "101"`)
+	spec := WarrantSpec{
+		ObjectType: "permission",
+		ObjectId:   "test",
+		Relation:   "member",
+		Subject: &SubjectSpec{
+			ObjectType: "user",
+			ObjectId:   "user-A",
+		},
+		Context: map[string]string{
+			"tenant": "101",
+		},
+	}
+	expectedWarrant := &Warrant{
+		ObjectType:  "permission",
+		ObjectId:    "test",
+		Relation:    "member",
+		SubjectType: "user",
+		SubjectId:   "user-A",
+		Policy:      policy,
+		PolicyHash:  policy.Hash(),
 	}
 	actualWarrant, err := spec.ToWarrant()
 	if err != nil {
@@ -95,6 +129,7 @@ func TestToWarrantIndirectWarrantSpec(t *testing.T) {
 }
 
 func TestToWarrantIndirectWarrantSpecWithPolicy(t *testing.T) {
+	policy := Policy("tenant == 101")
 	spec := WarrantSpec{
 		ObjectType: "permission",
 		ObjectId:   "test",
@@ -104,7 +139,7 @@ func TestToWarrantIndirectWarrantSpecWithPolicy(t *testing.T) {
 			ObjectId:   "admin",
 			Relation:   "member",
 		},
-		Policy: Policy("tenant == 101"),
+		Policy: policy,
 	}
 	expectedWarrant := &Warrant{
 		ObjectType:      "permission",
@@ -113,8 +148,43 @@ func TestToWarrantIndirectWarrantSpecWithPolicy(t *testing.T) {
 		SubjectType:     "role",
 		SubjectId:       "admin",
 		SubjectRelation: "member",
-		Policy:          spec.Policy,
-		PolicyHash:      spec.Policy.Hash(),
+		Policy:          policy,
+		PolicyHash:      policy.Hash(),
+	}
+	actualWarrant, err := spec.ToWarrant()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !cmp.Equal(actualWarrant, expectedWarrant) {
+		t.Fatalf("Expected warrant to be %v, but it was %v", expectedWarrant, actualWarrant)
+	}
+}
+
+func TestToWarrantIndirectWarrantSpecWithContext(t *testing.T) {
+	policy := Policy(`tenant == "101"`)
+	spec := WarrantSpec{
+		ObjectType: "permission",
+		ObjectId:   "test",
+		Relation:   "member",
+		Subject: &SubjectSpec{
+			ObjectType: "role",
+			ObjectId:   "admin",
+			Relation:   "member",
+		},
+		Context: map[string]string{
+			"tenant": "101",
+		},
+	}
+	expectedWarrant := &Warrant{
+		ObjectType:      "permission",
+		ObjectId:        "test",
+		Relation:        "member",
+		SubjectType:     "role",
+		SubjectId:       "admin",
+		SubjectRelation: "member",
+		Policy:          policy,
+		PolicyHash:      policy.Hash(),
 	}
 	actualWarrant, err := spec.ToWarrant()
 	if err != nil {
@@ -149,6 +219,7 @@ func TestToMapDirectWarrantSpec(t *testing.T) {
 }
 
 func TestToMapDirectWarrantSpecWithPolicy(t *testing.T) {
+	policy := Policy("tenant == 101")
 	spec := WarrantSpec{
 		ObjectType: "permission",
 		ObjectId:   "test",
@@ -157,14 +228,14 @@ func TestToMapDirectWarrantSpecWithPolicy(t *testing.T) {
 			ObjectType: "user",
 			ObjectId:   "user-A",
 		},
-		Policy: Policy("tenant == 101"),
+		Policy: policy,
 	}
 	expectedMap := map[string]interface{}{
 		"objectType": "permission",
 		"objectId":   "test",
 		"relation":   "member",
 		"subject":    spec.Subject.ToMap(),
-		"policy":     spec.Policy,
+		"policy":     policy,
 	}
 	actualMap := spec.ToMap()
 	if !cmp.Equal(actualMap, expectedMap) {
@@ -196,6 +267,7 @@ func TestToMapIndirectWarrantSpec(t *testing.T) {
 }
 
 func TestToMapIndirectWarrantSpecWithPolicy(t *testing.T) {
+	policy := Policy("tenant == 101")
 	spec := WarrantSpec{
 		ObjectType: "permission",
 		ObjectId:   "test",
@@ -205,14 +277,14 @@ func TestToMapIndirectWarrantSpecWithPolicy(t *testing.T) {
 			ObjectId:   "admin",
 			Relation:   "member",
 		},
-		Policy: Policy("tenant == 101"),
+		Policy: policy,
 	}
 	expectedMap := map[string]interface{}{
 		"objectType": "permission",
 		"objectId":   "test",
 		"relation":   "member",
 		"subject":    spec.Subject.ToMap(),
-		"policy":     spec.Policy,
+		"policy":     policy,
 	}
 	actualMap := spec.ToMap()
 	if !cmp.Equal(actualMap, expectedMap) {

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -73,12 +73,12 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	db.Mapper = reflectx.NewMapperFunc("mysql", func(s string) string { return s })
 
 	ds.DB = db
-	log.Ctx(ctx).Debug().Msgf("Connected to mysql database %s", ds.Config.Database)
+	log.Info().Msgf("Connected to mysql database %s", ds.Config.Database)
 	return nil
 }
 
 func (ds MySQL) Migrate(ctx context.Context, toVersion uint) error {
-	log.Ctx(ctx).Debug().Msgf("Migrating mysql database %s", ds.Config.Database)
+	log.Info().Msgf("Migrating mysql database %s", ds.Config.Database)
 	// migrate database to latest schema
 	mig, err := migrate.New(
 		ds.Config.MigrationSource,
@@ -99,18 +99,18 @@ func (ds MySQL) Migrate(ctx context.Context, toVersion uint) error {
 	}
 
 	if currentVersion == toVersion {
-		log.Ctx(ctx).Debug().Msg("Migrations already up-to-date")
+		log.Info().Msg("Migrations already up-to-date")
 		return nil
 	}
 
 	numStepsToMigrate := toVersion - currentVersion
-	log.Ctx(ctx).Debug().Msgf("Applying %d migration(s)", numStepsToMigrate)
+	log.Info().Msgf("Applying %d migration(s)", numStepsToMigrate)
 	err = mig.Steps(int(numStepsToMigrate))
 	if err != nil {
 		return errors.Wrap(err, "Error migrating mysql database")
 	}
 
-	log.Ctx(ctx).Debug().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
+	log.Info().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
 	return nil
 }
 

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -79,12 +79,12 @@ func (ds *Postgres) Connect(ctx context.Context) error {
 	db.Mapper = reflectx.NewMapperFunc("postgres", func(s string) string { return s })
 
 	ds.DB = db
-	log.Ctx(ctx).Debug().Msgf("Connected to postgres database %s", ds.Config.Database)
+	log.Info().Msgf("Connected to postgres database %s", ds.Config.Database)
 	return nil
 }
 
 func (ds Postgres) Migrate(ctx context.Context, toVersion uint) error {
-	log.Ctx(ctx).Debug().Msgf("Migrating postgres database %s", ds.Config.Database)
+	log.Info().Msgf("Migrating postgres database %s", ds.Config.Database)
 	// migrate database to latest schema
 	usernamePassword := url.UserPassword(ds.Config.Username, ds.Config.Password).String()
 	mig, err := migrate.New(
@@ -106,18 +106,18 @@ func (ds Postgres) Migrate(ctx context.Context, toVersion uint) error {
 	}
 
 	if currentVersion == toVersion {
-		log.Ctx(ctx).Debug().Msg("Migrations already up-to-date")
+		log.Info().Msg("Migrations already up-to-date")
 		return nil
 	}
 
 	numStepsToMigrate := toVersion - currentVersion
-	log.Ctx(ctx).Debug().Msgf("Applying %d migration(s)", numStepsToMigrate)
+	log.Info().Msgf("Applying %d migration(s)", numStepsToMigrate)
 	err = mig.Steps(int(numStepsToMigrate))
 	if err != nil {
 		return errors.Wrap(err, "Error migrating postgres database")
 	}
 
-	log.Ctx(ctx).Debug().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
+	log.Info().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
 	return nil
 }
 

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -71,12 +71,12 @@ func (ds *SQLite) Connect(ctx context.Context) error {
 	db.Mapper = reflectx.NewMapperFunc("sqlite", func(s string) string { return s })
 
 	ds.DB = db
-	log.Ctx(ctx).Debug().Msgf("Connected to sqlite database %s", ds.Config.Database)
+	log.Info().Msgf("Connected to sqlite database %s", ds.Config.Database)
 	return nil
 }
 
 func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
-	log.Ctx(ctx).Debug().Msgf("Migrating sqlite database %s", ds.Config.Database)
+	log.Info().Msgf("Migrating sqlite database %s", ds.Config.Database)
 	// migrate database to latest schema
 	instance, err := sqlite3.WithInstance(ds.DB.DB, &sqlite3.Config{})
 	if err != nil {
@@ -102,18 +102,18 @@ func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
 	}
 
 	if currentVersion == toVersion {
-		log.Ctx(ctx).Debug().Msg("Migrations already up-to-date")
+		log.Info().Msg("Migrations already up-to-date")
 		return nil
 	}
 
 	numStepsToMigrate := toVersion - currentVersion
-	log.Ctx(ctx).Debug().Msgf("Applying %d migration(s)", numStepsToMigrate)
+	log.Info().Msgf("Applying %d migration(s)", numStepsToMigrate)
 	err = mig.Steps(int(numStepsToMigrate))
 	if err != nil {
 		return errors.Wrap(err, "Error migrating sqlite database")
 	}
 
-	log.Ctx(ctx).Debug().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
+	log.Info().Msgf("Migrations for database %s up-to-date.", ds.Config.Database)
 	return nil
 }
 

--- a/tests/authz-policy.json
+++ b/tests/authz-policy.json
@@ -33,6 +33,65 @@
             }
         },
         {
+            "name": "assignWarrantWithContext",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "context": {
+                        "element": "115"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "policy": "element == \"115\""
+                }
+            }
+        },
+        {
+            "name": "failToCreateWarrantWithPolicyAndContext",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "policy": "element == \"115\"",
+                    "context": {
+                        "element": "115"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 400,
+                "body": {
+                    "code": "invalid_request",
+                    "message": "Invalid request body"
+                }
+            }
+        },
+        {
             "name": "assignWarrantWithRegexPolicy",
             "request": {
                 "method": "POST",
@@ -171,6 +230,28 @@
                         "objectId": "user-a"
                     },
                     "policy": "clientIp matches \"192\\.168\\..*\\..*\""
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeWarrantWithContext",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "context": {
+                        "element": "115"
+                    }
                 }
             },
             "expectedResponse": {


### PR DESCRIPTION
## Describe your changes
This PR adds back support for providing `context` when creating/deleting a warrant in order to keep those endpoints backwards compatible even with the addition of warrant policies. If `context` is passed when creating a warrant, the endpoint will automatically convert the context into a policy which is the `&&` (AND) of the key value pairs passed in the `context`. The same logic will apply when `context` is passed to the delete warrant endpoint.

## Issue number and link (if applicable)
N/A