### PR TITLE
Update resource list endpoint pagination to handle null and empty string values better

### DIFF
--- a/pkg/authz/feature/handlers.go
+++ b/pkg/authz/feature/handlers.go
@@ -81,7 +81,7 @@ func GetHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) erro
 }
 
 func ListHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[FeatureListParamParser](r.Context())
 	features, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/feature/list.go
+++ b/pkg/authz/feature/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "featureId"
+
 type FeatureListParamParser struct{}
 
 func (parser FeatureListParamParser) GetDefaultSortBy() string {
-	return "featureId"
+	return defaultSortBy
 }
 
 func (parser FeatureListParamParser) GetSupportedSortBys() []string {
@@ -30,7 +32,6 @@ func (parser FeatureListParamParser) ParseValue(val string, sortBy string) (inte
 		}
 
 		return val, nil
-
 	case "name":
 		if val == "" {
 			return "", nil

--- a/pkg/authz/feature/list.go
+++ b/pkg/authz/feature/list.go
@@ -23,7 +23,7 @@ func (parser FeatureListParamParser) ParseValue(val string, sortBy string) (inte
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "featureId":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -122,13 +122,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -156,7 +156,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -139,18 +139,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -182,18 +180,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -124,72 +124,124 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND featureId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND featureId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND featureId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND featureId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "featureId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, featureId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY featureId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -123,7 +123,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -140,18 +140,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -183,18 +181,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -120,66 +120,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (feature_id LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (feature_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (feature_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND feature_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND feature_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (feature_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (feature_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND feature_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND feature_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -189,12 +220,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "featureId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, feature_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY feature_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -212,26 +212,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -121,14 +121,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (feature_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (feature_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -156,7 +156,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (feature_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -122,7 +122,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (feature_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/feature/sqlite.go
+++ b/pkg/authz/feature/sqlite.go
@@ -129,7 +129,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/feature/sqlite.go
+++ b/pkg/authz/feature/sqlite.go
@@ -145,18 +145,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -188,18 +186,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/feature/sqlite.go
+++ b/pkg/authz/feature/sqlite.go
@@ -130,72 +130,124 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND featureId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND featureId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND featureId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND featureId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "featureId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, featureId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY featureId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/feature/sqlite.go
+++ b/pkg/authz/feature/sqlite.go
@@ -128,13 +128,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (featureId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (featureId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -162,7 +162,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (featureId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/object/handlers.go
+++ b/pkg/authz/object/handlers.go
@@ -58,7 +58,7 @@ func CreateHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) er
 }
 
 func ListHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[ObjectListParamParser](r.Context())
 	queryParams := r.URL.Query()
 	objectType, err := url.QueryUnescape(queryParams.Get("objectType"))
 	if err != nil {

--- a/pkg/authz/object/list.go
+++ b/pkg/authz/object/list.go
@@ -23,7 +23,7 @@ func (parser ObjectListParamParser) ParseValue(val string, sortBy string) (inter
 			return nil, fmt.Errorf("must be a valid time in the %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "objectType", "objectId":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/object/list.go
+++ b/pkg/authz/object/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "objectId"
+
 type ObjectListParamParser struct{}
 
 func (parser ObjectListParamParser) GetDefaultSortBy() string {
-	return "objectId"
+	return defaultSortBy
 }
 
 func (parser ObjectListParamParser) GetSupportedSortBys() []string {

--- a/pkg/authz/object/mysql.go
+++ b/pkg/authz/object/mysql.go
@@ -135,18 +135,16 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -178,18 +176,16 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/object/mysql.go
+++ b/pkg/authz/object/mysql.go
@@ -118,13 +118,13 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 		replacements = append(replacements, filterOptions.ObjectType)
 	}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -152,7 +152,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/object/mysql.go
+++ b/pkg/authz/object/mysql.go
@@ -119,7 +119,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 	}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/object/mysql.go
+++ b/pkg/authz/object/mysql.go
@@ -120,72 +120,124 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (objectType LIKE ? OR %s LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND objectId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND objectId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND objectId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND objectId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "objectId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, objectId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY objectId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -118,7 +118,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 	}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (object_type LIKE ? OR object_id LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -136,18 +136,16 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -179,18 +177,16 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -117,14 +117,14 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 		replacements = append(replacements, filterOptions.ObjectType)
 	}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (object_type LIKE ? OR object_id LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (object_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -152,7 +152,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (object_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -208,26 +208,28 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -111,6 +111,8 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if filterOptions != nil && filterOptions.ObjectType != "" {
 		query = fmt.Sprintf("%s AND object_type = ?", query)
@@ -119,63 +121,92 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (object_type LIKE ? OR object_id LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (object_type LIKE ? OR %s LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (object_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (object_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND object_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND object_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (object_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (object_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND object_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND object_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -185,14 +216,35 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "objectId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, object_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY object_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
-
 	err := repo.DB(ctx).SelectContext(
 		ctx,
 		&objects,

--- a/pkg/authz/object/sqlite.go
+++ b/pkg/authz/object/sqlite.go
@@ -139,18 +139,16 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/object/sqlite.go
+++ b/pkg/authz/object/sqlite.go
@@ -122,13 +122,13 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 		replacements = append(replacements, filterOptions.ObjectType)
 	}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -156,7 +156,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/object/sqlite.go
+++ b/pkg/authz/object/sqlite.go
@@ -123,7 +123,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 	}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/object/sqlite.go
+++ b/pkg/authz/object/sqlite.go
@@ -124,72 +124,124 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (objectType LIKE ? OR objectId LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (objectType LIKE ? OR %s LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND objectId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND objectId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (objectId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (objectId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND objectId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND objectId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "objectId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, objectId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY objectId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/objecttype/handlers.go
+++ b/pkg/authz/objecttype/handlers.go
@@ -72,7 +72,7 @@ func CreateHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request
 }
 
 func ListHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[ObjectTypeListParamParser](r.Context())
 	objectTypeSpecs, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/objecttype/list.go
+++ b/pkg/authz/objecttype/list.go
@@ -5,10 +5,13 @@ import (
 	"time"
 )
 
+const defaultSortBy = "objectType"
+const defaultSortByColumn = "typeId"
+
 type ObjectTypeListParamParser struct{}
 
 func (parser ObjectTypeListParamParser) GetDefaultSortBy() string {
-	return "objectType"
+	return defaultSortBy
 }
 
 func (parser ObjectTypeListParamParser) GetSupportedSortBys() []string {

--- a/pkg/authz/objecttype/list.go
+++ b/pkg/authz/objecttype/list.go
@@ -23,7 +23,7 @@ func (parser ObjectTypeListParamParser) ParseValue(val string, sortBy string) (i
 			return nil, fmt.Errorf("must be a valid time in the %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "objectType":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -115,72 +115,124 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND typeId LIKE ?", query)
+		query = fmt.Sprintf("%s AND %s LIKE ?", query, defaultSortByColumn)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (typeId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (typeId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND typeId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND typeId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (typeId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortByColumn, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (typeId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortByColumn, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND typeId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND typeId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "objectType" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, typeId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortByColumn, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortByColumn, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortByColumn, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY typeId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortByColumn, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortByColumn, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -113,13 +113,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			deletedAt IS NULL
 	`
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND typeId LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (typeId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -147,7 +147,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (typeId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -130,18 +130,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -173,18 +171,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortByColumn, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortByColumn, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -114,7 +114,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND typeId LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -131,18 +131,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortColumn, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -174,18 +172,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortColumn, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -113,7 +113,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND type_id LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -111,66 +111,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		WHERE
 			deleted_at IS NULL
 	`
+	defaultSortColumn := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortByColumn, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND type_id LIKE ?", query)
+		query = fmt.Sprintf("%s AND %s LIKE ?", query, defaultSortColumn)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (type_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortColumn, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (type_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND type_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND type_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (type_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortColumn, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (type_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortColumn, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSortColumn, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND type_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND type_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSortColumn, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -180,12 +211,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "objectType" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, type_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortColumn, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortColumn, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortColumn, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY type_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortColumn, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSortColumn, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -112,14 +112,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND type_id LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (type_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -147,7 +147,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (type_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -203,26 +203,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortColumn, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSortColumn, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortColumn, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSortColumn, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortColumn, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/objecttype/sqlite.go
+++ b/pkg/authz/objecttype/sqlite.go
@@ -118,7 +118,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND typeId LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/objecttype/sqlite.go
+++ b/pkg/authz/objecttype/sqlite.go
@@ -117,13 +117,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			deletedAt IS NULL
 	`
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND typeId LIKE ?", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (typeId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -151,7 +151,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (typeId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/objecttype/sqlite.go
+++ b/pkg/authz/objecttype/sqlite.go
@@ -134,18 +134,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -177,18 +175,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortByColumn, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortByColumn, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortByColumn, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/permission/handlers.go
+++ b/pkg/authz/permission/handlers.go
@@ -81,7 +81,7 @@ func GetHandler(svc PermissionService, w http.ResponseWriter, r *http.Request) e
 }
 
 func ListHandler(svc PermissionService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[PermissionListParamParser](r.Context())
 	permissions, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/permission/list.go
+++ b/pkg/authz/permission/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "permissionId"
+
 type PermissionListParamParser struct{}
 
 func (parser PermissionListParamParser) GetDefaultSortBy() string {
-	return "permissionId"
+	return defaultSortBy
 }
 
 func (parser PermissionListParamParser) GetSupportedSortBys() []string {

--- a/pkg/authz/permission/list.go
+++ b/pkg/authz/permission/list.go
@@ -23,7 +23,7 @@ func (parser PermissionListParamParser) ParseValue(val string, sortBy string) (i
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "permissionId":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/permission/mysql.go
+++ b/pkg/authz/permission/mysql.go
@@ -123,7 +123,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (permissionId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/permission/mysql.go
+++ b/pkg/authz/permission/mysql.go
@@ -122,13 +122,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (permissionId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (permissionId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -156,7 +156,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (permissionId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/permission/mysql.go
+++ b/pkg/authz/permission/mysql.go
@@ -139,18 +139,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -182,18 +180,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -140,18 +140,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -183,18 +181,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -121,14 +121,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (permission_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (permission_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -156,7 +156,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (permission_id < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -212,26 +212,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -120,66 +120,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (permission_id LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (permission_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (permission_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND permission_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND permission_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (permission_id < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (permission_id > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND permission_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND permission_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -189,12 +220,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "permissionId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, permission_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY permission_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -122,7 +122,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (permission_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/permission/sqlite.go
+++ b/pkg/authz/permission/sqlite.go
@@ -126,13 +126,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (permissionId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (permissionId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -160,7 +160,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (permissionId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/permission/sqlite.go
+++ b/pkg/authz/permission/sqlite.go
@@ -127,7 +127,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (permissionId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/permission/sqlite.go
+++ b/pkg/authz/permission/sqlite.go
@@ -143,18 +143,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -186,18 +184,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/permission/sqlite.go
+++ b/pkg/authz/permission/sqlite.go
@@ -128,72 +128,124 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (permissionId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (permissionId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (permissionId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND permissionId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND permissionId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (permissionId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (permissionId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND permissionId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND permissionId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "permissionId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, permissionId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY permissionId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/pricingtier/handlers.go
+++ b/pkg/authz/pricingtier/handlers.go
@@ -81,7 +81,7 @@ func GetHandler(svc PricingTierService, w http.ResponseWriter, r *http.Request) 
 }
 
 func ListHandler(svc PricingTierService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[PricingTierListParamParser](r.Context())
 	pricingTiers, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/pricingtier/list.go
+++ b/pkg/authz/pricingtier/list.go
@@ -23,7 +23,7 @@ func (parser PricingTierListParamParser) ParseValue(val string, sortBy string) (
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "pricingTierId":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/pricingtier/list.go
+++ b/pkg/authz/pricingtier/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "pricingTierId"
+
 type PricingTierListParamParser struct{}
 
 func (parser PricingTierListParamParser) GetDefaultSortBy() string {
-	return "pricingTierId"
+	return defaultSortBy
 }
 
 func (parser PricingTierListParamParser) GetSupportedSortBys() []string {

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -123,7 +123,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -139,18 +139,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -182,18 +180,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -124,72 +124,124 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricingTierId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricingTierId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricingTierId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricingTierId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "pricingTierId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, pricingTierId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY pricingTierId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -122,13 +122,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -156,7 +156,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -212,26 +212,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortBy, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSortBy, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortBy, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSortBy, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -140,18 +140,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -183,18 +181,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -120,66 +120,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (pricing_tier_id LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricing_tier_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricing_tier_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricing_tier_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricing_tier_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricing_tier_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricing_tier_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricing_tier_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricing_tier_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -189,12 +220,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "pricingTierId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, pricing_tier_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY pricing_tier_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -122,7 +122,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (pricing_tier_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -121,14 +121,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (pricing_tier_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (pricing_tier_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -156,7 +156,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (pricing_tier_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -221,13 +221,13 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSortBy, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSortBy, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
-			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
@@ -240,10 +240,10 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	} else {
 		if listParams.SortBy != defaultSortBy {
-			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortBy, listParams.SortOrder)
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 			replacements = append(replacements, listParams.Limit)
 		} else {
-			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder, nullSortClause)
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
 			replacements = append(replacements, listParams.Limit)
 		}
 	}

--- a/pkg/authz/pricingtier/sqlite.go
+++ b/pkg/authz/pricingtier/sqlite.go
@@ -126,13 +126,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -160,7 +160,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/pricingtier/sqlite.go
+++ b/pkg/authz/pricingtier/sqlite.go
@@ -128,72 +128,124 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricingTierId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricingTierId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (pricingTierId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (pricingTierId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND pricingTierId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND pricingTierId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "pricingTierId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, pricingTierId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY pricingTierId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/pricingtier/sqlite.go
+++ b/pkg/authz/pricingtier/sqlite.go
@@ -127,7 +127,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (pricingTierId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/pricingtier/sqlite.go
+++ b/pkg/authz/pricingtier/sqlite.go
@@ -143,18 +143,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -186,18 +184,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/role/handlers.go
+++ b/pkg/authz/role/handlers.go
@@ -81,7 +81,7 @@ func GetHandler(svc RoleService, w http.ResponseWriter, r *http.Request) error {
 }
 
 func ListHandler(svc RoleService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[RoleListParamParser](r.Context())
 	roles, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/role/list.go
+++ b/pkg/authz/role/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "roleId"
+
 type RoleListParamParser struct{}
 
 func (parser RoleListParamParser) GetDefaultSortBy() string {
-	return "roleId"
+	return defaultSortBy
 }
 
 func (parser RoleListParamParser) GetSupportedSortBys() []string {
@@ -30,7 +32,6 @@ func (parser RoleListParamParser) ParseValue(val string, sortBy string) (interfa
 		}
 
 		return val, nil
-
 	case "name":
 		if val == "" {
 			return "", nil

--- a/pkg/authz/role/list.go
+++ b/pkg/authz/role/list.go
@@ -23,7 +23,7 @@ func (parser RoleListParamParser) ParseValue(val string, sortBy string) (interfa
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "roleId":
 		if val == "" {
 			return nil, fmt.Errorf("must not be empty")

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -122,13 +122,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -156,7 +156,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -123,7 +123,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -124,72 +124,124 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND roleId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND roleId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND roleId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND roleId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "roleId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, roleId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY roleId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -139,18 +139,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -182,18 +180,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -140,18 +140,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -183,18 +181,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -212,26 +212,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -120,66 +120,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (role_id LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (role_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (role_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND role_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND role_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (role_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (role_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND role_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND role_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -189,12 +220,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "roleId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, role_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY role_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -122,7 +122,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (role_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -121,14 +121,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (role_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (role_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -156,7 +156,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (role_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/role/sqlite.go
+++ b/pkg/authz/role/sqlite.go
@@ -126,13 +126,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -160,7 +160,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/role/sqlite.go
+++ b/pkg/authz/role/sqlite.go
@@ -127,7 +127,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/role/sqlite.go
+++ b/pkg/authz/role/sqlite.go
@@ -128,72 +128,124 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (roleId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND roleId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND roleId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (roleId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (roleId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND roleId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND roleId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "roleId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, roleId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY roleId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/role/sqlite.go
+++ b/pkg/authz/role/sqlite.go
@@ -143,18 +143,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -186,18 +184,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/tenant/handlers.go
+++ b/pkg/authz/tenant/handlers.go
@@ -81,7 +81,7 @@ func GetHandler(svc TenantService, w http.ResponseWriter, r *http.Request) error
 }
 
 func ListHandler(svc TenantService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[TenantListParamParser](r.Context())
 	tenants, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/tenant/list.go
+++ b/pkg/authz/tenant/list.go
@@ -23,7 +23,7 @@ func (parser TenantListParamParser) ParseValue(val string, sortBy string) (inter
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "name":
 		if val == "" {
 			return "", nil

--- a/pkg/authz/tenant/list.go
+++ b/pkg/authz/tenant/list.go
@@ -5,10 +5,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "tenantId"
+
 type TenantListParamParser struct{}
 
 func (parser TenantListParamParser) GetDefaultSortBy() string {
-	return "tenantId"
+	return defaultSortBy
 }
 
 func (parser TenantListParamParser) GetSupportedSortBys() []string {

--- a/pkg/authz/tenant/mysql.go
+++ b/pkg/authz/tenant/mysql.go
@@ -136,18 +136,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -179,18 +177,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/tenant/mysql.go
+++ b/pkg/authz/tenant/mysql.go
@@ -120,7 +120,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/tenant/mysql.go
+++ b/pkg/authz/tenant/mysql.go
@@ -119,13 +119,13 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -153,7 +153,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/tenant/mysql.go
+++ b/pkg/authz/tenant/mysql.go
@@ -121,72 +121,124 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenantId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenantId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenantId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenantId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "tenantId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, tenantId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY tenantId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -137,18 +137,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -180,18 +178,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -214,16 +214,17 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 		invertedNullSortClause = "NULLS LAST"
 	}
+
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSortBy, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSortBy, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
-			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
@@ -236,10 +237,10 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	} else {
 		if listParams.SortBy != defaultSortBy {
-			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortBy, listParams.SortOrder)
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 			replacements = append(replacements, listParams.Limit)
 		} else {
-			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder, nullSortClause)
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
 			replacements = append(replacements, listParams.Limit)
 		}
 	}

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -117,66 +117,97 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (tenant_id LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenant_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenant_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenant_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenant_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenant_id < ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenant_id > ? AND %s = ?))", query, sortBy, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenant_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenant_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
@@ -186,12 +217,34 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "tenantId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, tenant_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY tenant_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder, nullSortClause)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -209,26 +209,27 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
-
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSortBy, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSortBy, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSortBy, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSortBy, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, sortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -118,14 +118,14 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (tenant_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (tenant_id > ? AND %s = ?))", query, sortBy, sortBy)
@@ -153,7 +153,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (tenant_id < ? AND %s = ?))", query, sortBy, sortBy)

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -119,7 +119,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (tenant_id LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/tenant/sqlite.go
+++ b/pkg/authz/tenant/sqlite.go
@@ -123,13 +123,13 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
+	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
+	if listParams.AfterId != nil {
 		if listParams.AfterValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
@@ -157,7 +157,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.BeforeId != "" {
+	if listParams.BeforeId != nil {
 		if listParams.BeforeValue != nil {
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)

--- a/pkg/authz/tenant/sqlite.go
+++ b/pkg/authz/tenant/sqlite.go
@@ -125,72 +125,124 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 
 	if listParams.Query != nil {
 		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
-		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR name LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
 	if listParams.AfterId != nil {
-		if listParams.AfterValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterValue,
-					listParams.AfterId,
-					listParams.AfterValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenantId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenantId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterValue,
+					listParams.AfterId,
+					listParams.AfterValue,
+				)
 			}
 		}
 	}
 
 	if listParams.BeforeId != nil {
-		if listParams.BeforeValue != nil {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (tenantId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (tenantId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeValue,
-					listParams.BeforeId,
-					listParams.BeforeValue,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
-		} else {
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND tenantId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			} else {
-				query = fmt.Sprintf("%s AND tenantId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeValue,
+					listParams.BeforeId,
+					listParams.BeforeValue,
+				)
 			}
 		}
 	}
 
-	if listParams.SortBy != "tenantId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, tenantId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY tenantId %s LIMIT ?", query, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/tenant/sqlite.go
+++ b/pkg/authz/tenant/sqlite.go
@@ -124,7 +124,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (tenantId LIKE ? OR name LIKE ?)", query)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/tenant/sqlite.go
+++ b/pkg/authz/tenant/sqlite.go
@@ -140,18 +140,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -183,18 +181,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/handlers.go
+++ b/pkg/authz/user/handlers.go
@@ -80,7 +80,7 @@ func GetHandler(svc UserService, w http.ResponseWriter, r *http.Request) error {
 }
 
 func ListHandler(svc UserService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[UserListParamParser](r.Context())
 	users, err := svc.List(r.Context(), listParams)
 	if err != nil {
 		return err

--- a/pkg/authz/user/list.go
+++ b/pkg/authz/user/list.go
@@ -6,10 +6,12 @@ import (
 	"time"
 )
 
+const defaultSortBy = "userId"
+
 type UserListParamParser struct{}
 
 func (parser UserListParamParser) GetDefaultSortBy() string {
-	return "userId"
+	return defaultSortBy
 }
 
 func (parser UserListParamParser) GetSupportedSortBys() []string {
@@ -24,7 +26,7 @@ func (parser UserListParamParser) ParseValue(val string, sortBy string) (interfa
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	case "email":
 		if val == "" {
 			return "", nil

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -118,7 +118,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -195,12 +195,34 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	if listParams.SortBy != defaultSortBy {
-		query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -134,18 +134,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -177,18 +175,16 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -140,7 +140,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 					listParams.AfterId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
@@ -156,13 +156,6 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 					listParams.AfterValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
-			replacements = append(replacements,
-				listParams.AfterValue,
-				listParams.AfterId,
-				listParams.AfterValue,
-			)
 		}
 	}
 
@@ -183,7 +176,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 					listParams.BeforeId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
@@ -199,13 +192,6 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 					listParams.BeforeValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
-			replacements = append(replacements,
-				listParams.BeforeValue,
-				listParams.BeforeId,
-				listParams.BeforeValue,
-			)
 		}
 	}
 

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -118,7 +118,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -117,73 +117,103 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 	`
 	replacements := []interface{}{}
 
-	if listParams.Query != "" {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
-		query = fmt.Sprintf("%s AND (userId LIKE ? OR email LIKE ?)", query)
+	if listParams.Query != nil {
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	if listParams.AfterId != "" {
-		if listParams.AfterValue != nil {
+	if listParams.AfterId != nil {
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
+			} else {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
+			}
+		case "":
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (userId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
 					listParams.AfterValue,
 					listParams.AfterId,
 					listParams.AfterValue,
 				)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (userId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
 					listParams.AfterValue,
 					listParams.AfterId,
 					listParams.AfterValue,
 				)
 			}
-		} else {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND userId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			} else {
-				query = fmt.Sprintf("%s AND userId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			}
+		default:
+			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+			replacements = append(replacements,
+				listParams.AfterValue,
+				listParams.AfterId,
+				listParams.AfterValue,
+			)
 		}
 	}
 
-	if listParams.BeforeId != "" {
-		if listParams.BeforeValue != nil {
+	if listParams.BeforeId != nil {
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
+			} else {
+				query = fmt.Sprintf("%s AND (%s IS NULL OR (%s %s ? AND %s IS NOT NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
+			}
+		case "":
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (userId < ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
 					listParams.BeforeValue,
 					listParams.BeforeId,
 					listParams.BeforeValue,
 				)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (userId > ? AND %s = ?))", query, listParams.SortBy, listParams.SortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
 					listParams.BeforeValue,
 					listParams.BeforeId,
 					listParams.BeforeValue,
 				)
 			}
-		} else {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND userId < ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			} else {
-				query = fmt.Sprintf("%s AND userId > ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			}
+		default:
+			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
+			replacements = append(replacements,
+				listParams.BeforeValue,
+				listParams.BeforeId,
+				listParams.BeforeValue,
+			)
 		}
 	}
 
-	if listParams.SortBy != "userId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s, userId %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, listParams.SortOrder)
+	if listParams.SortBy != defaultSortBy {
+		query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
 		replacements = append(replacements, listParams.Limit)
 	} else {
-		query = fmt.Sprintf("%s ORDER BY userId %s LIMIT ?", query, listParams.SortOrder)
+		query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
 		replacements = append(replacements, listParams.Limit)
 	}
 

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -135,10 +135,17 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -171,10 +178,17 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NULL OR (%s %s ? AND %s IS NOT NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -135,18 +135,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.AfterId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -178,18 +176,16 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -119,7 +119,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -115,67 +115,98 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 			deleted_at IS NULL
 	`
 	replacements := []interface{}{}
+	defaultSort := regexp.MustCompile("([A-Z])").ReplaceAllString(defaultSortBy, `_$1`)
+	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
-	if listParams.Query != "" {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
-		query = fmt.Sprintf("%s AND (user_id LIKE ? OR email LIKE ?)", query)
+	if listParams.Query != nil {
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
+		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}
 
-	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
-	if listParams.AfterId != "" {
-		if listParams.AfterValue != nil {
+	if listParams.AfterId != nil {
+		comparisonOp := "<"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = ">"
+		}
+
+		switch listParams.AfterValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.AfterId)
+			} else {
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.AfterId,
+				)
+			}
+		case "":
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s > ? OR (user_id > ? AND %s = ?))", query, sortBy, sortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
 					listParams.AfterValue,
 					listParams.AfterId,
 					listParams.AfterValue,
 				)
 			} else {
-				query = fmt.Sprintf("%s AND (%s < ? OR (user_id < ? AND %s = ?))", query, sortBy, sortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
 					listParams.AfterValue,
 					listParams.AfterId,
 					listParams.AfterValue,
 				)
 			}
-		} else {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND user_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			} else {
-				query = fmt.Sprintf("%s AND user_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			}
+		default:
+			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+			replacements = append(replacements,
+				listParams.AfterValue,
+				listParams.AfterId,
+				listParams.AfterValue,
+			)
 		}
 	}
 
-	if listParams.BeforeId != "" {
-		if listParams.BeforeValue != nil {
+	if listParams.BeforeId != nil {
+		comparisonOp := ">"
+		if listParams.SortOrder == service.SortOrderAsc {
+			comparisonOp = "<"
+		}
+
+		switch listParams.BeforeValue {
+		case nil:
+			if listParams.SortBy == defaultSortBy {
+				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
+				replacements = append(replacements, listParams.BeforeId)
+			} else {
+				query = fmt.Sprintf("%s AND (%s IS NULL OR (%s %s ? AND %s IS NOT NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
+			}
+		case "":
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND (%s < ? OR (user_id < ? AND %s = ?))", query, sortBy, sortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
 					listParams.BeforeValue,
 					listParams.BeforeId,
 					listParams.BeforeValue,
 				)
 			} else {
-				query = fmt.Sprintf("%s AND (%s > ? OR (user_id > ? AND %s = ?))", query, sortBy, sortBy)
+				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
 					listParams.BeforeValue,
 					listParams.BeforeId,
 					listParams.BeforeValue,
 				)
 			}
-		} else {
-			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s AND user_id < ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			} else {
-				query = fmt.Sprintf("%s AND user_id > ?", query)
-				replacements = append(replacements, listParams.AfterId)
-			}
+		default:
+			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
+			replacements = append(replacements,
+				listParams.BeforeValue,
+				listParams.BeforeId,
+				listParams.BeforeValue,
+			)
 		}
 	}
 
@@ -184,11 +215,11 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		nullSortClause = "NULLS FIRST"
 	}
 
-	if listParams.SortBy != "userId" {
-		query = fmt.Sprintf("%s ORDER BY %s %s %s, user_id %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, listParams.SortOrder)
+	if listParams.SortBy != defaultSortBy {
+		query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		replacements = append(replacements, listParams.Limit)
 	} else {
-		query = fmt.Sprintf("%s ORDER BY user_id %s %s LIMIT ?", query, listParams.SortOrder, nullSortClause)
+		query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, defaultSort, listParams.SortOrder, nullSortClause)
 		replacements = append(replacements, listParams.Limit)
 	}
 

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -141,7 +141,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 					listParams.AfterId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
@@ -157,13 +157,6 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 					listParams.AfterValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
-			replacements = append(replacements,
-				listParams.AfterValue,
-				listParams.AfterId,
-				listParams.AfterValue,
-			)
 		}
 	}
 
@@ -184,7 +177,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 					listParams.BeforeId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, sortBy, defaultSort, comparisonOp, sortBy)
 				replacements = append(replacements,
@@ -200,13 +193,6 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 					listParams.BeforeValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, sortBy, comparisonOp, defaultSort, comparisonOp, sortBy)
-			replacements = append(replacements,
-				listParams.BeforeValue,
-				listParams.BeforeId,
-				listParams.BeforeValue,
-			)
 		}
 	}
 

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -119,7 +119,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSort)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -207,26 +207,28 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 	}
 
 	nullSortClause := "NULLS LAST"
+	invertedNullSortClause := "NULLS FIRST"
 	if listParams.SortOrder == service.SortOrderAsc {
 		nullSortClause = "NULLS FIRST"
+		invertedNullSortClause = "NULLS LAST"
 	}
 
 	if listParams.BeforeId != nil {
 		if listParams.SortBy != defaultSortBy {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause, defaultSort, service.SortOrderDesc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause, defaultSort, service.SortOrderDesc)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause, defaultSort, service.SortOrderAsc)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s, %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause, defaultSort, service.SortOrderAsc)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s, %s %s", query, sortBy, listParams.SortOrder, nullSortClause, defaultSort, listParams.SortOrder)
 		} else {
 			if listParams.SortOrder == service.SortOrderAsc {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderDesc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			} else {
-				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, nullSortClause)
+				query = fmt.Sprintf("%s ORDER BY %s %s %s LIMIT ?", query, sortBy, service.SortOrderAsc, invertedNullSortClause)
 				replacements = append(replacements, listParams.Limit)
 			}
 			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s %s", query, sortBy, listParams.SortOrder, nullSortClause)

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -136,10 +136,17 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-				replacements = append(replacements,
-					listParams.AfterId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -172,10 +179,17 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSort, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NULL OR (%s %s ? AND %s IS NOT NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
-				replacements = append(replacements,
-					listParams.BeforeId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, sortBy, defaultSort, comparisonOp, sortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -139,10 +139,17 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.AfterId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.AfterId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.AfterId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {
@@ -175,10 +182,17 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
 			} else {
-				query = fmt.Sprintf("%s AND (%s IS NULL OR (%s %s ? AND %s IS NOT NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-				replacements = append(replacements,
-					listParams.BeforeId,
-				)
+				if listParams.SortOrder == service.SortOrderAsc {
+					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				} else {
+					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+					replacements = append(replacements,
+						listParams.BeforeId,
+					)
+				}
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -181,18 +181,16 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 			if listParams.SortBy == defaultSortBy {
 				query = fmt.Sprintf("%s AND %s %s ?", query, defaultSortBy, comparisonOp)
 				replacements = append(replacements, listParams.BeforeId)
+			} else if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			} else {
-				if listParams.SortOrder == service.SortOrderAsc {
-					query = fmt.Sprintf("%s AND (%s %s ? AND %s IS NULL)", query, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				} else {
-					query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
-					replacements = append(replacements,
-						listParams.BeforeId,
-					)
-				}
+				query = fmt.Sprintf("%s AND (%s IS NOT NULL OR (%s %s ? AND %s IS NULL))", query, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
+				replacements = append(replacements,
+					listParams.BeforeId,
+				)
 			}
 		default:
 			if listParams.SortOrder == service.SortOrderAsc {

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -144,7 +144,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 					listParams.AfterId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
@@ -160,13 +160,6 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 					listParams.AfterValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
-			replacements = append(replacements,
-				listParams.AfterValue,
-				listParams.AfterId,
-				listParams.AfterValue,
-			)
 		}
 	}
 
@@ -187,7 +180,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 					listParams.BeforeId,
 				)
 			}
-		case "":
+		default:
 			if listParams.SortOrder == service.SortOrderAsc {
 				query = fmt.Sprintf("%s AND (%s %s ? OR %s IS NULL OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, listParams.SortBy, defaultSortBy, comparisonOp, listParams.SortBy)
 				replacements = append(replacements,
@@ -203,13 +196,6 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 					listParams.BeforeValue,
 				)
 			}
-		default:
-			query = fmt.Sprintf("%s AND (%s %s ? OR (%s %s ? AND %s = ?))", query, listParams.SortBy, comparisonOp, defaultSortBy, comparisonOp, listParams.SortBy)
-			replacements = append(replacements,
-				listParams.BeforeValue,
-				listParams.BeforeId,
-				listParams.BeforeValue,
-			)
 		}
 	}
 

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -122,7 +122,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -199,12 +199,34 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	if listParams.SortBy != defaultSortBy {
-		query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+	if listParams.BeforeId != nil {
+		if listParams.SortBy != defaultSortBy {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc, defaultSortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc, defaultSortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s, %s %s", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+		} else {
+			if listParams.SortOrder == service.SortOrderAsc {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderDesc)
+				replacements = append(replacements, listParams.Limit)
+			} else {
+				query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, listParams.SortBy, service.SortOrderAsc)
+				replacements = append(replacements, listParams.Limit)
+			}
+			query = fmt.Sprintf("With result_set AS (%s) SELECT * FROM result_set ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
+		}
 	} else {
-		query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
-		replacements = append(replacements, listParams.Limit)
+		if listParams.SortBy != defaultSortBy {
+			query = fmt.Sprintf("%s ORDER BY %s %s, %s %s LIMIT ?", query, listParams.SortBy, listParams.SortOrder, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		} else {
+			query = fmt.Sprintf("%s ORDER BY %s %s LIMIT ?", query, defaultSortBy, listParams.SortOrder)
+			replacements = append(replacements, listParams.Limit)
+		}
 	}
 
 	err := repo.DB(ctx).SelectContext(

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -122,7 +122,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 	replacements := []interface{}{}
 
 	if listParams.Query != nil {
-		searchTermReplacement := fmt.Sprintf("%%%s%%", *listParams.Query)
+		searchTermReplacement := fmt.Sprintf("%%%s%%", listParams.Query)
 		query = fmt.Sprintf("%s AND (%s LIKE ? OR email LIKE ?)", query, defaultSortBy)
 		replacements = append(replacements, searchTermReplacement, searchTermReplacement)
 	}

--- a/pkg/authz/warrant/handlers.go
+++ b/pkg/authz/warrant/handlers.go
@@ -64,7 +64,7 @@ func CreateHandler(svc WarrantService, w http.ResponseWriter, r *http.Request) e
 }
 
 func ListHandler(svc WarrantService, w http.ResponseWriter, r *http.Request) error {
-	listParams := service.GetListParamsFromContext(r.Context())
+	listParams := service.GetListParamsFromContext[WarrantListParamParser](r.Context())
 	queryParams := r.URL.Query()
 	filters := FilterOptions{
 		ObjectType: queryParams.Get("objectType"),

--- a/pkg/authz/warrant/list.go
+++ b/pkg/authz/warrant/list.go
@@ -22,10 +22,12 @@ type SortOptions struct {
 	IsAscending bool
 }
 
+const defaultSortBy = "createdAt"
+
 type WarrantListParamParser struct{}
 
 func (parser WarrantListParamParser) GetDefaultSortBy() string {
-	return "createdAt"
+	return defaultSortBy
 }
 
 func (parser WarrantListParamParser) GetSupportedSortBys() []string {
@@ -40,7 +42,7 @@ func (parser WarrantListParamParser) ParseValue(val string, sortBy string) (inte
 			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
-		return afterValue, nil
+		return &afterValue, nil
 	default:
 		return nil, fmt.Errorf("must match type of selected sortBy attribute %s", sortBy)
 	}

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -261,8 +261,6 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 
 	if listParams.SortBy != "" {
 		query = fmt.Sprintf("%s ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
-	} else {
-		query = fmt.Sprintf("%s ORDER BY createdAt DESC, id DESC", query)
 	}
 
 	offset := (listParams.Page - 1) * listParams.Limit

--- a/pkg/authz/warrant/postgres.go
+++ b/pkg/authz/warrant/postgres.go
@@ -262,8 +262,6 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 	if listParams.SortBy != "" {
 		sortBy := regexp.MustCompile("([A-Z])").ReplaceAllString(listParams.SortBy, `_$1`)
 		query = fmt.Sprintf(`%s ORDER BY %s %s`, query, sortBy, listParams.SortOrder)
-	} else {
-		query = fmt.Sprintf(`%s ORDER BY created_at DESC, id DESC`, query)
 	}
 
 	query = fmt.Sprintf(`%s LIMIT ? OFFSET ?`, query)

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -266,8 +266,6 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 
 	if listParams.SortBy != "" {
 		query = fmt.Sprintf("%s ORDER BY %s %s", query, listParams.SortBy, listParams.SortOrder)
-	} else {
-		query = fmt.Sprintf("%s ORDER BY createdAt DESC, id DESC", query)
 	}
 
 	query = fmt.Sprintf("%s LIMIT ?, ?", query)

--- a/pkg/service/middleware.go
+++ b/pkg/service/middleware.go
@@ -208,6 +208,11 @@ func ListMiddleware[T ListParamParser](next http.Handler) http.Handler {
 			return
 		}
 
+		if (urlQueryParams.Has(paramNameBeforeId) || urlQueryParams.Has(paramNameBeforeValue)) && (urlQueryParams.Has(paramNameAfterId) || urlQueryParams.Has(paramNameAfterValue)) {
+			SendErrorResponse(w, NewInvalidRequestError(fmt.Sprintf("cannot pass both %s or %s along with %s or %s", paramNameBeforeId, paramNameBeforeValue, paramNameAfterId, paramNameAfterValue)))
+			return
+		}
+
 		defaultSortBy := listParamParser.GetDefaultSortBy()
 		if (urlQueryParams.Has(paramNameAfterValue) || urlQueryParams.Has(paramNameBeforeValue)) && sortBy == defaultSortBy {
 			SendErrorResponse(w, NewInvalidRequestError(fmt.Sprintf("cannot pass %s or %s when sorting by %s", paramNameAfterValue, paramNameBeforeValue, defaultSortBy)))

--- a/pkg/service/middleware.go
+++ b/pkg/service/middleware.go
@@ -209,7 +209,7 @@ func ListMiddleware[T ListParamParser](next http.Handler) http.Handler {
 		}
 
 		if (urlQueryParams.Has(paramNameBeforeId) || urlQueryParams.Has(paramNameBeforeValue)) && (urlQueryParams.Has(paramNameAfterId) || urlQueryParams.Has(paramNameAfterValue)) {
-			SendErrorResponse(w, NewInvalidRequestError(fmt.Sprintf("cannot pass both %s or %s along with %s or %s", paramNameBeforeId, paramNameBeforeValue, paramNameAfterId, paramNameAfterValue)))
+			SendErrorResponse(w, NewInvalidRequestError(fmt.Sprintf("cannot pass %s and/or %s with %s and/or %s", paramNameBeforeId, paramNameBeforeValue, paramNameAfterId, paramNameAfterValue)))
 			return
 		}
 

--- a/tests/features-list.json
+++ b/tests/features-list.json
@@ -10,14 +10,14 @@
                 "url": "/v1/features",
                 "body": {
                     "featureId": "feature-1",
-                    "name": "Feature B"
+                    "name": "Feature A"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-1",
-                    "name": "Feature B",
+                    "name": "Feature A",
                     "description": null
                 }
             }
@@ -29,14 +29,14 @@
                 "url": "/v1/features",
                 "body": {
                     "featureId": "feature-2",
-                    "name": "Feature A"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-2",
-                    "name": "Feature A",
+                    "name": "",
                     "description": null
                 }
             }
@@ -48,14 +48,14 @@
                 "url": "/v1/features",
                 "body": {
                     "featureId": "feature-3",
-                    "name": ""
+                    "name": null
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-3",
-                    "name": "",
+                    "name": null,
                     "description": null
                 }
             }
@@ -98,7 +98,7 @@
             }
         },
         {
-            "name": "getFeaturesSortByCreatedAtDESC",
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?sortBy=createdAt&sortOrder=DESC"
@@ -118,24 +118,24 @@
                     },
                     {
                         "featureId": "feature-3",
-                        "name": "",
+                        "name": null,
                         "description": null
                     },
                     {
                         "featureId": "feature-2",
-                        "name": "Feature A",
+                        "name": "",
                         "description": null
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
+                        "name": "Feature A",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesSortByCreatedAtASC",
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?sortBy=createdAt&sortOrder=ASC"
@@ -145,17 +145,17 @@
                 "body": [
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
-                        "description": null
-                    },
-                    {
-                        "featureId": "feature-2",
                         "name": "Feature A",
                         "description": null
                     },
                     {
-                        "featureId": "feature-3",
+                        "featureId": "feature-2",
                         "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
                         "description": null
                     },
                     {
@@ -172,7 +172,7 @@
             }
         },
         {
-            "name": "getFeaturesSortByNameDESC",
+            "name": "sortByNameDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?sortBy=name&sortOrder=DESC"
@@ -187,16 +187,11 @@
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
-                        "description": null
-                    },
-                    {
-                        "featureId": "feature-2",
                         "name": "Feature A",
                         "description": null
                     },
                     {
-                        "featureId": "feature-3",
+                        "featureId": "feature-2",
                         "name": "",
                         "description": null
                     },
@@ -204,15 +199,47 @@
                         "featureId": "feature-4",
                         "name": null,
                         "description": null
+                    },
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesSortByNameASC",
+            "name": "sortByNameDESCWithLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC"
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-5",
+                        "name": "Feature C",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature A",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-2",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=3&afterId=feature-2&afterValue="
             },
             "expectedResponse": {
                 "statusCode": 200,
@@ -224,17 +251,39 @@
                     },
                     {
                         "featureId": "feature-3",
-                        "name": "",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-4",
+                        "name": null,
                         "description": null
                     },
                     {
                         "featureId": "feature-2",
-                        "name": "Feature A",
+                        "name": "",
                         "description": null
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
+                        "name": "Feature A",
                         "description": null
                     },
                     {
@@ -246,10 +295,27 @@
             }
         },
         {
-            "name": "getFeaturesSortByNameASCLimit2",
+            "name": "sortByNameASCWithLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2"
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1&afterId=feature-3"
             },
             "expectedResponse": {
                 "statusCode": 200,
@@ -258,17 +324,112 @@
                         "featureId": "feature-4",
                         "name": null,
                         "description": null
-                    },
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1&beforeId=feature-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
                     {
                         "featureId": "feature-3",
-                        "name": "",
+                        "name": null,
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesSortByCreatedAtASCLimit2",
+            "name": "sortByNameASCAfterValueNullNextValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature A",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-1&afterValue=Feature%20A"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-5",
+                        "name": "Feature C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-5&beforeValue=Feature%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature A",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-2&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-4",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASCWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?sortBy=createdAt&sortOrder=ASC&limit=2"
@@ -278,19 +439,19 @@
                 "body": [
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
+                        "name": "Feature A",
                         "description": null
                     },
                     {
                         "featureId": "feature-2",
-                        "name": "Feature A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesLimit2",
+            "name": "noSortWithLimit2",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?limit=2"
@@ -300,19 +461,19 @@
                 "body": [
                     {
                         "featureId": "feature-1",
-                        "name": "Feature B",
+                        "name": "Feature A",
                         "description": null
                     },
                     {
                         "featureId": "feature-2",
-                        "name": "Feature A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesLimit2AfterId1",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?limit=2&afterId=feature-1"
@@ -322,31 +483,26 @@
                 "body": [
                     {
                         "featureId": "feature-2",
-                        "name": "Feature A",
+                        "name": "",
                         "description": null
                     },
                     {
                         "featureId": "feature-3",
-                        "name": "",
+                        "name": null,
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getFeaturesLimit2AfterId2",
+            "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?limit=2&afterId=feature-3"
+                "url": "/v1/features?limit=2&afterId=feature-4"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
-                    {
-                        "featureId": "feature-4",
-                        "name": null,
-                        "description": null
-                    },
                     {
                         "featureId": "feature-5",
                         "name": "Feature C",

--- a/tests/features-list.json
+++ b/tests/features-list.json
@@ -10,14 +10,14 @@
                 "url": "/v1/features",
                 "body": {
                     "featureId": "feature-1",
-                    "name": "Feature A"
+                    "name": "Feature B"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-1",
-                    "name": "Feature A",
+                    "name": "Feature B",
                     "description": null
                 }
             }
@@ -47,8 +47,7 @@
                 "method": "POST",
                 "url": "/v1/features",
                 "body": {
-                    "featureId": "feature-3",
-                    "name": null
+                    "featureId": "feature-3"
                 }
             },
             "expectedResponse": {
@@ -66,14 +65,15 @@
                 "method": "POST",
                 "url": "/v1/features",
                 "body": {
-                    "featureId": "feature-4"
+                    "featureId": "feature-4",
+                    "name": "Feature C"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-4",
-                    "name": null,
+                    "name": "Feature C",
                     "description": null
                 }
             }
@@ -85,14 +85,32 @@
                 "url": "/v1/features",
                 "body": {
                     "featureId": "feature-5",
-                    "name": "Feature C"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "featureId": "feature-5",
-                    "name": "Feature C",
+                    "name": "",
+                    "description": null
+                }
+            }
+        },
+        {
+            "name": "createFeature6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/features",
+                "body": {
+                    "featureId": "feature-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "featureId": "feature-6",
+                    "name": null,
                     "description": null
                 }
             }
@@ -107,13 +125,18 @@
                 "statusCode": 200,
                 "body": [
                     {
+                        "featureId": "feature-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
                         "featureId": "feature-5",
-                        "name": "Feature C",
+                        "name": "",
                         "description": null
                     },
                     {
                         "featureId": "feature-4",
-                        "name": null,
+                        "name": "Feature C",
                         "description": null
                     },
                     {
@@ -128,7 +151,34 @@
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature A",
+                        "name": "Feature B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-4",
+                        "name": "Feature C",
                         "description": null
                     }
                 ]
@@ -145,7 +195,7 @@
                 "body": [
                     {
                         "featureId": "feature-1",
-                        "name": "Feature A",
+                        "name": "Feature B",
                         "description": null
                     },
                     {
@@ -160,12 +210,39 @@
                     },
                     {
                         "featureId": "feature-4",
-                        "name": null,
+                        "name": "Feature C",
                         "description": null
                     },
                     {
                         "featureId": "feature-5",
-                        "name": "Feature C",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=createdAt&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature B",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-2",
+                        "name": "",
                         "description": null
                     }
                 ]
@@ -181,13 +258,18 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-5",
+                        "featureId": "feature-4",
                         "name": "Feature C",
                         "description": null
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature A",
+                        "name": "Feature B",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-5",
+                        "name": "",
                         "description": null
                     },
                     {
@@ -196,7 +278,7 @@
                         "description": null
                     },
                     {
-                        "featureId": "feature-4",
+                        "featureId": "feature-6",
                         "name": null,
                         "description": null
                     },
@@ -218,18 +300,69 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-5",
+                        "featureId": "feature-4",
                         "name": "Feature C",
                         "description": null
                     },
                     {
                         "featureId": "feature-1",
-                        "name": "Feature A",
+                        "name": "Feature B",
                         "description": null
                     },
                     {
-                        "featureId": "feature-2",
+                        "featureId": "feature-5",
                         "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=1&beforeId=feature-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=1&afterId=feature-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=1&beforeId=feature-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature B",
                         "description": null
                     }
                 ]
@@ -239,19 +372,63 @@
             "name": "sortByNameDESCAfterValueEmptyString",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=3&afterId=feature-2&afterValue="
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=3&afterId=feature-5&afterValue="
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-4",
+                        "featureId": "feature-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-6",
                         "name": null,
                         "description": null
                     },
                     {
                         "featureId": "feature-3",
                         "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=1&beforeId=feature-1&beforeValue=Feature%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-4",
+                        "name": "Feature C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=DESC&limit=2&afterId=feature-4&afterValue=Feature%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature B",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-5",
+                        "name": "",
                         "description": null
                     }
                 ]
@@ -272,7 +449,7 @@
                         "description": null
                     },
                     {
-                        "featureId": "feature-4",
+                        "featureId": "feature-6",
                         "name": null,
                         "description": null
                     },
@@ -282,12 +459,17 @@
                         "description": null
                     },
                     {
-                        "featureId": "feature-1",
-                        "name": "Feature A",
+                        "featureId": "feature-5",
+                        "name": "",
                         "description": null
                     },
                     {
-                        "featureId": "feature-5",
+                        "featureId": "feature-1",
+                        "name": "Feature B",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-4",
                         "name": "Feature C",
                         "description": null
                     }
@@ -298,7 +480,29 @@
             "name": "sortByNameASCWithLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1"
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1&beforeId=feature-6"
             },
             "expectedResponse": {
                 "statusCode": 200,
@@ -321,86 +525,8 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-4",
+                        "featureId": "feature-6",
                         "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByNameASCBeforeValueNull",
-            "request": {
-                "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=1&beforeId=feature-4"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "featureId": "feature-3",
-                        "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByNameASCAfterValueNullNextValueEmptyString",
-            "request": {
-                "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-4"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "featureId": "feature-2",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "featureId": "feature-1",
-                        "name": "Feature A",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByNameASCValidAfterValue",
-            "request": {
-                "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-1&afterValue=Feature%20A"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "featureId": "feature-5",
-                        "name": "Feature C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByNameASCValidBeforeValue",
-            "request": {
-                "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-5&beforeValue=Feature%20C"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "featureId": "feature-2",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "featureId": "feature-1",
-                        "name": "Feature A",
                         "description": null
                     }
                 ]
@@ -410,36 +536,14 @@
             "name": "sortByNameASCBeforeValueEmptyString",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-2&beforeValue="
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-5&beforeValue="
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-3",
+                        "featureId": "feature-6",
                         "name": null,
-                        "description": null
-                    },
-                    {
-                        "featureId": "feature-4",
-                        "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByCreatedAtASCWithLimit",
-            "request": {
-                "method": "GET",
-                "url": "/v1/features?sortBy=createdAt&sortOrder=ASC&limit=2"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "featureId": "feature-1",
-                        "name": "Feature A",
                         "description": null
                     },
                     {
@@ -451,7 +555,68 @@
             }
         },
         {
-            "name": "noSortWithLimit2",
+            "name": "sortByNameASCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&beforeId=feature-4&beforeValue=Feature%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-1",
+                        "name": "Feature B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/features?sortBy=name&sortOrder=ASC&limit=2&afterId=feature-1&afterValue=Feature%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "featureId": "feature-4",
+                        "name": "Feature C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/features?limit=2"
@@ -461,7 +626,7 @@
                 "body": [
                     {
                         "featureId": "feature-1",
-                        "name": "Feature A",
+                        "name": "Feature B",
                         "description": null
                     },
                     {
@@ -476,19 +641,19 @@
             "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?limit=2&afterId=feature-1"
+                "url": "/v1/features?limit=2&afterId=feature-2"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "featureId": "feature-2",
-                        "name": "",
+                        "featureId": "feature-3",
+                        "name": null,
                         "description": null
                     },
                     {
-                        "featureId": "feature-3",
-                        "name": null,
+                        "featureId": "feature-4",
+                        "name": "Feature C",
                         "description": null
                     }
                 ]
@@ -498,14 +663,19 @@
             "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/features?limit=2&afterId=feature-4"
+                "url": "/v1/features?limit=3&afterId=feature-4"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
                         "featureId": "feature-5",
-                        "name": "Feature C",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "featureId": "feature-6",
+                        "name": null,
                         "description": null
                     }
                 ]
@@ -556,6 +726,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/features/feature-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteFeature6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/features/feature-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/permissions-list.json
+++ b/tests/permissions-list.json
@@ -29,14 +29,14 @@
                 "url": "/v1/permissions",
                 "body": {
                     "permissionId": "permission-2",
-                    "name": "Permission A"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "permissionId": "permission-2",
-                    "name": "Permission A",
+                    "name": "",
                     "description": null
                 }
             }
@@ -47,15 +47,14 @@
                 "method": "POST",
                 "url": "/v1/permissions",
                 "body": {
-                    "permissionId": "permission-3",
-                    "name": ""
+                    "permissionId": "permission-3"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "permissionId": "permission-3",
-                    "name": "",
+                    "name": null,
                     "description": null
                 }
             }
@@ -66,14 +65,15 @@
                 "method": "POST",
                 "url": "/v1/permissions",
                 "body": {
-                    "permissionId": "permission-4"
+                    "permissionId": "permission-4",
+                    "name": "Permission C"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "permissionId": "permission-4",
-                    "name": null,
+                    "name": "Permission C",
                     "description": null
                 }
             }
@@ -85,20 +85,38 @@
                 "url": "/v1/permissions",
                 "body": {
                     "permissionId": "permission-5",
-                    "name": "Permission C"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "permissionId": "permission-5",
-                    "name": "Permission C",
+                    "name": "",
                     "description": null
                 }
             }
         },
         {
-            "name": "getPermissionsSortByCreatedAtDESC",
+            "name": "createPermission6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/permissions",
+                "body": {
+                    "permissionId": "permission-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "permissionId": "permission-6",
+                    "name": null,
+                    "description": null
+                }
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/permissions?sortBy=createdAt&sortOrder=DESC"
@@ -107,23 +125,28 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "permissionId": "permission-5",
-                        "name": "Permission C",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-4",
+                        "permissionId": "permission-6",
                         "name": null,
                         "description": null
                     },
                     {
-                        "permissionId": "permission-3",
+                        "permissionId": "permission-5",
                         "name": "",
                         "description": null
                     },
                     {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
                         "permissionId": "permission-2",
-                        "name": "Permission A",
+                        "name": "",
                         "description": null
                     },
                     {
@@ -135,7 +158,34 @@
             }
         },
         {
-            "name": "getPermissionsSortByCreatedAtASC",
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/permissions?sortBy=createdAt&sortOrder=ASC"
@@ -150,125 +200,34 @@
                     },
                     {
                         "permissionId": "permission-2",
-                        "name": "Permission A",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-3",
                         "name": "",
                         "description": null
                     },
                     {
-                        "permissionId": "permission-4",
+                        "permissionId": "permission-3",
                         "name": null,
                         "description": null
                     },
                     {
-                        "permissionId": "permission-5",
-                        "name": "Permission C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPermissionsSortByNameDESC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/permissions?sortBy=name&sortOrder=DESC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "permissionId": "permission-5",
+                        "permissionId": "permission-4",
                         "name": "Permission C",
                         "description": null
                     },
                     {
-                        "permissionId": "permission-1",
-                        "name": "Permission B",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-2",
-                        "name": "Permission A",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-4",
-                        "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPermissionsSortByNameASC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/permissions?sortBy=name&sortOrder=ASC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "permissionId": "permission-4",
-                        "name": null,
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-2",
-                        "name": "Permission A",
-                        "description": null
-                    },
-                    {
-                        "permissionId": "permission-1",
-                        "name": "Permission B",
-                        "description": null
-                    },
-                    {
                         "permissionId": "permission-5",
-                        "name": "Permission C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPermissionsSortByNameASCLimit2",
-            "request": {
-                "method": "GET",
-                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "permissionId": "permission-4",
-                        "name": null,
+                        "name": "",
                         "description": null
                     },
                     {
-                        "permissionId": "permission-3",
-                        "name": "",
+                        "permissionId": "permission-6",
+                        "name": null,
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPermissionsSortByCreatedAtASCLimit2",
+            "name": "sortByCreatedAtASCWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/permissions?sortBy=createdAt&sortOrder=ASC&limit=2"
@@ -283,14 +242,381 @@
                     },
                     {
                         "permissionId": "permission-2",
-                        "name": "Permission A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPermissionsLimit2",
+            "name": "sortByNameDESC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=1&beforeId=permission-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=1&afterId=permission-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=1&beforeId=permission-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=3&afterId=permission-5&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=1&beforeId=permission-1&beforeValue=Permission%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=DESC&limit=2&afterId=permission-4&afterValue=Permission%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=1&beforeId=permission-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=1&afterId=permission-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2&beforeId=permission-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-2",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2&afterId=permission-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2&beforeId=permission-4&beforeValue=Permission%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-1",
+                        "name": "Permission B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/permissions?sortBy=name&sortOrder=ASC&limit=2&afterId=permission-1&afterValue=Permission%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "permissionId": "permission-4",
+                        "name": "Permission C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/permissions?limit=2"
@@ -305,14 +631,14 @@
                     },
                     {
                         "permissionId": "permission-2",
-                        "name": "Permission A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPermissionsLimit2AfterId1",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
                 "url": "/v1/permissions?limit=2&afterId=permission-2"
@@ -322,29 +648,34 @@
                 "body": [
                     {
                         "permissionId": "permission-3",
-                        "name": "",
+                        "name": null,
                         "description": null
                     },
                     {
                         "permissionId": "permission-4",
-                        "name": null,
+                        "name": "Permission C",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPermissionsLimit2AfterId2",
+            "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/permissions?limit=2&afterId=permission-4"
+                "url": "/v1/permissions?limit=3&afterId=permission-4"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
                         "permissionId": "permission-5",
-                        "name": "Permission C",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "permissionId": "permission-6",
+                        "name": null,
                         "description": null
                     }
                 ]
@@ -395,6 +726,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/permissions/permission-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermission6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/permissions/permission-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/pricing-tiers.list.json
+++ b/tests/pricing-tiers.list.json
@@ -29,14 +29,14 @@
                 "url": "/v1/pricing-tiers",
                 "body": {
                     "pricingTierId": "pricing-tier-2",
-                    "name": "Pricing Tier A"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "pricingTierId": "pricing-tier-2",
-                    "name": "Pricing Tier A",
+                    "name": "",
                     "description": null
                 }
             }
@@ -47,15 +47,14 @@
                 "method": "POST",
                 "url": "/v1/pricing-tiers",
                 "body": {
-                    "pricingTierId": "pricing-tier-3",
-                    "name": ""
+                    "pricingTierId": "pricing-tier-3"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "pricingTierId": "pricing-tier-3",
-                    "name": "",
+                    "name": null,
                     "description": null
                 }
             }
@@ -66,14 +65,15 @@
                 "method": "POST",
                 "url": "/v1/pricing-tiers",
                 "body": {
-                    "pricingTierId": "pricing-tier-4"
+                    "pricingTierId": "pricing-tier-4",
+                    "name": "Pricing Tier C"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "pricingTierId": "pricing-tier-4",
-                    "name": null,
+                    "name": "Pricing Tier C",
                     "description": null
                 }
             }
@@ -85,20 +85,38 @@
                 "url": "/v1/pricing-tiers",
                 "body": {
                     "pricingTierId": "pricing-tier-5",
-                    "name": "Pricing Tier C"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "pricingTierId": "pricing-tier-5",
-                    "name": "Pricing Tier C",
+                    "name": "",
                     "description": null
                 }
             }
         },
         {
-            "name": "getPricingTiersSortByCreatedAtDESC",
+            "name": "createPricingTier6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/pricing-tiers",
+                "body": {
+                    "pricingTierId": "pricing-tier-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "pricingTierId": "pricing-tier-6",
+                    "name": null,
+                    "description": null
+                }
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/pricing-tiers?sortBy=createdAt&sortOrder=DESC"
@@ -107,23 +125,28 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "pricingTierId": "pricing-tier-5",
-                        "name": "Pricing Tier C",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-4",
+                        "pricingTierId": "pricing-tier-6",
                         "name": null,
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-3",
+                        "pricingTierId": "pricing-tier-5",
                         "name": "",
                         "description": null
                     },
                     {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
                         "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
+                        "name": "",
                         "description": null
                     },
                     {
@@ -135,7 +158,34 @@
             }
         },
         {
-            "name": "getPricingTiersSortByCreatedAtASC",
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/pricing-tiers?sortBy=createdAt&sortOrder=ASC"
@@ -150,125 +200,34 @@
                     },
                     {
                         "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-3",
                         "name": "",
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-4",
+                        "pricingTierId": "pricing-tier-3",
                         "name": null,
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-5",
-                        "name": "Pricing Tier C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPricingTiersSortByNameDESC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "pricingTierId": "pricing-tier-5",
+                        "pricingTierId": "pricing-tier-4",
                         "name": "Pricing Tier C",
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-1",
-                        "name": "Pricing Tier B",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-4",
-                        "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPricingTiersSortByNameASC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "pricingTierId": "pricing-tier-4",
-                        "name": null,
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-1",
-                        "name": "Pricing Tier B",
-                        "description": null
-                    },
-                    {
                         "pricingTierId": "pricing-tier-5",
-                        "name": "Pricing Tier C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPricingTiersSortByNameASCLimit2",
-            "request": {
-                "method": "GET",
-                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "pricingTierId": "pricing-tier-4",
-                        "name": null,
+                        "name": "",
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-3",
-                        "name": "",
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPricingTiersSortByCreatedAtASCLimit2",
+            "name": "sortByCreatedAtASCWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/pricing-tiers?sortBy=createdAt&sortOrder=ASC&limit=2"
@@ -283,14 +242,381 @@
                     },
                     {
                         "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getPricingTiersLimit2",
+            "name": "sortByNameDESC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=1&beforeId=pricing-tier-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=1&afterId=pricing-tier-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=1&beforeId=pricing-tier-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=3&afterId=pricing-tier-5&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=1&beforeId=pricing-tier-1&beforeValue=Pricing%20Tier%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=DESC&limit=2&afterId=pricing-tier-4&afterValue=Pricing%20Tier%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=1&beforeId=pricing-tier-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=1&afterId=pricing-tier-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2&beforeId=pricing-tier-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-2",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2&afterId=pricing-tier-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2&beforeId=pricing-tier-4&beforeValue=Pricing%20Tier%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-1",
+                        "name": "Pricing Tier B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?sortBy=name&sortOrder=ASC&limit=2&afterId=pricing-tier-1&afterValue=Pricing%20Tier%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-4",
+                        "name": "Pricing Tier C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/pricing-tiers?limit=2"
@@ -305,28 +631,6 @@
                     },
                     {
                         "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getPricingTiersLimit2AfterId1",
-            "request": {
-                "method": "GET",
-                "url": "/v1/pricing-tiers?limit=2&afterId=pricing-tier-1"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "pricingTierId": "pricing-tier-2",
-                        "name": "Pricing Tier A",
-                        "description": null
-                    },
-                    {
-                        "pricingTierId": "pricing-tier-3",
                         "name": "",
                         "description": null
                     }
@@ -334,22 +638,44 @@
             }
         },
         {
-            "name": "getPricingTiersLimit2AfterId2",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
-                "url": "/v1/pricing-tiers?limit=2&afterId=pricing-tier-3"
+                "url": "/v1/pricing-tiers?limit=2&afterId=pricing-tier-2"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "pricingTierId": "pricing-tier-4",
+                        "pricingTierId": "pricing-tier-3",
                         "name": null,
                         "description": null
                     },
                     {
-                        "pricingTierId": "pricing-tier-5",
+                        "pricingTierId": "pricing-tier-4",
                         "name": "Pricing Tier C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortResultSmallerThanLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/pricing-tiers?limit=3&afterId=pricing-tier-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "pricingTierId": "pricing-tier-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "pricingTierId": "pricing-tier-6",
+                        "name": null,
                         "description": null
                     }
                 ]
@@ -400,6 +726,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/pricing-tiers/pricing-tier-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePricingTier6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/pricing-tiers/pricing-tier-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/roles-list.json
+++ b/tests/roles-list.json
@@ -29,14 +29,14 @@
                 "url": "/v1/roles",
                 "body": {
                     "roleId": "role-2",
-                    "name": "Role A"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "roleId": "role-2",
-                    "name": "Role A",
+                    "name": "",
                     "description": null
                 }
             }
@@ -47,15 +47,14 @@
                 "method": "POST",
                 "url": "/v1/roles",
                 "body": {
-                    "roleId": "role-3",
-                    "name": ""
+                    "roleId": "role-3"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "roleId": "role-3",
-                    "name": "",
+                    "name": null,
                     "description": null
                 }
             }
@@ -66,14 +65,15 @@
                 "method": "POST",
                 "url": "/v1/roles",
                 "body": {
-                    "roleId": "role-4"
+                    "roleId": "role-4",
+                    "name": "Role C"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "roleId": "role-4",
-                    "name": null,
+                    "name": "Role C",
                     "description": null
                 }
             }
@@ -85,20 +85,38 @@
                 "url": "/v1/roles",
                 "body": {
                     "roleId": "role-5",
-                    "name": "Role C"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "roleId": "role-5",
-                    "name": "Role C",
+                    "name": "",
                     "description": null
                 }
             }
         },
         {
-            "name": "getRolesSortByCreatedAtDESC",
+            "name": "createRole6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/roles",
+                "body": {
+                    "roleId": "role-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "roleId": "role-6",
+                    "name": null,
+                    "description": null
+                }
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/roles?sortBy=createdAt&sortOrder=DESC"
@@ -107,23 +125,28 @@
                 "statusCode": 200,
                 "body": [
                     {
-                        "roleId": "role-5",
-                        "name": "Role C",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-4",
+                        "roleId": "role-6",
                         "name": null,
                         "description": null
                     },
                     {
-                        "roleId": "role-3",
+                        "roleId": "role-5",
                         "name": "",
                         "description": null
                     },
                     {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
                         "roleId": "role-2",
-                        "name": "Role A",
+                        "name": "",
                         "description": null
                     },
                     {
@@ -135,7 +158,34 @@
             }
         },
         {
-            "name": "getRolesSortByCreatedAtASC",
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/roles?sortBy=createdAt&sortOrder=ASC"
@@ -150,125 +200,34 @@
                     },
                     {
                         "roleId": "role-2",
-                        "name": "Role A",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-3",
                         "name": "",
                         "description": null
                     },
                     {
-                        "roleId": "role-4",
+                        "roleId": "role-3",
                         "name": null,
                         "description": null
                     },
                     {
-                        "roleId": "role-5",
-                        "name": "Role C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getRolesSortByNameDESC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/roles?sortBy=name&sortOrder=DESC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "roleId": "role-5",
+                        "roleId": "role-4",
                         "name": "Role C",
                         "description": null
                     },
                     {
-                        "roleId": "role-1",
-                        "name": "Role B",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-2",
-                        "name": "Role A",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-4",
-                        "name": null,
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getRolesSortByNameASC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/roles?sortBy=name&sortOrder=ASC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "roleId": "role-4",
-                        "name": null,
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-3",
-                        "name": "",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-2",
-                        "name": "Role A",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-1",
-                        "name": "Role B",
-                        "description": null
-                    },
-                    {
                         "roleId": "role-5",
-                        "name": "Role C",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getRolesSortByNameASCLimit2",
-            "request": {
-                "method": "GET",
-                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "roleId": "role-4",
-                        "name": null,
+                        "name": "",
                         "description": null
                     },
                     {
-                        "roleId": "role-3",
-                        "name": "",
+                        "roleId": "role-6",
+                        "name": null,
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getRolesSortByCreatedAtASCLimit2",
+            "name": "sortByCreatedAtASCWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/roles?sortBy=createdAt&sortOrder=ASC&limit=2"
@@ -283,14 +242,381 @@
                     },
                     {
                         "roleId": "role-2",
-                        "name": "Role A",
+                        "name": "",
                         "description": null
                     }
                 ]
             }
         },
         {
-            "name": "getRolesLimit2",
+            "name": "sortByNameDESC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=1&beforeId=role-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=1&afterId=role-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=1&beforeId=role-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=3&afterId=role-5&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=1&beforeId=role-1&beforeValue=Role%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=DESC&limit=2&afterId=role-4&afterValue=Role%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-2",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=1&beforeId=role-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-3",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=1&afterId=role-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2&beforeId=role-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-6",
+                        "name": null,
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-2",
+                        "name": "",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2&afterId=role-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2&beforeId=role-4&beforeValue=Role%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-1",
+                        "name": "Role B",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?sortBy=name&sortOrder=ASC&limit=2&afterId=role-1&afterValue=Role%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-4",
+                        "name": "Role C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/roles?limit=2"
@@ -305,28 +631,6 @@
                     },
                     {
                         "roleId": "role-2",
-                        "name": "Role A",
-                        "description": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getRolesLimit2AfterId1",
-            "request": {
-                "method": "GET",
-                "url": "/v1/roles?limit=2&afterId=role-1"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "roleId": "role-2",
-                        "name": "Role A",
-                        "description": null
-                    },
-                    {
-                        "roleId": "role-3",
                         "name": "",
                         "description": null
                     }
@@ -334,22 +638,44 @@
             }
         },
         {
-            "name": "getRolesLimit2AfterId2",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
-                "url": "/v1/roles?limit=2&afterId=role-3"
+                "url": "/v1/roles?limit=2&afterId=role-2"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "roleId": "role-4",
+                        "roleId": "role-3",
                         "name": null,
                         "description": null
                     },
                     {
-                        "roleId": "role-5",
+                        "roleId": "role-4",
                         "name": "Role C",
+                        "description": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "noSortResultSmallerThanLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/roles?limit=3&afterId=role-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "roleId": "role-5",
+                        "name": "",
+                        "description": null
+                    },
+                    {
+                        "roleId": "role-6",
+                        "name": null,
                         "description": null
                     }
                 ]
@@ -400,6 +726,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/roles/role-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRole6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/roles/role-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/tenants-list.json
+++ b/tests/tenants-list.json
@@ -28,14 +28,14 @@
                 "url": "/v1/tenants",
                 "body": {
                     "tenantId": "tenant-2",
-                    "name": "Tenant A"
+                    "name": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "tenantId": "tenant-2",
-                    "name": "Tenant A"
+                    "name": ""
                 }
             }
         },
@@ -93,7 +93,24 @@
             }
         },
         {
-            "name": "getTenantsSortByCreatedAtDESC",
+            "name": "createTenant6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/tenants",
+                "body": {
+                    "tenantId": "tenant-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "tenantId": "tenant-6",
+                    "name": null
+                }
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?sortBy=createdAt&sortOrder=DESC"
@@ -101,6 +118,10 @@
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
+                    },
                     {
                         "tenantId": "tenant-5",
                         "name": "Tenant C"
@@ -115,7 +136,7 @@
                     },
                     {
                         "tenantId": "tenant-2",
-                        "name": "Tenant A"
+                        "name": ""
                     },
                     {
                         "tenantId": "tenant-1",
@@ -125,7 +146,31 @@
             }
         },
         {
-            "name": "getTenantsSortByCreatedAtASC",
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
+                    },
+                    {
+                        "tenantId": "tenant-5",
+                        "name": "Tenant C"
+                    },
+                    {
+                        "tenantId": "tenant-4",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?sortBy=createdAt&sortOrder=ASC"
@@ -139,7 +184,7 @@
                     },
                     {
                         "tenantId": "tenant-2",
-                        "name": "Tenant A"
+                        "name": ""
                     },
                     {
                         "tenantId": "tenant-3",
@@ -152,12 +197,36 @@
                     {
                         "tenantId": "tenant-5",
                         "name": "Tenant C"
+                    },
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
                     }
                 ]
             }
         },
         {
-            "name": "getTenantsSortByNameDESC",
+            "name": "sortByCreatedAtASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=createdAt&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-1",
+                        "name": "Tenant B"
+                    },
+                    {
+                        "tenantId": "tenant-2",
+                        "name": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?sortBy=name&sortOrder=DESC"
@@ -174,12 +243,16 @@
                         "name": "Tenant B"
                     },
                     {
-                        "tenantId": "tenant-2",
-                        "name": "Tenant A"
-                    },
-                    {
                         "tenantId": "tenant-3",
                         "name": ""
+                    },
+                    {
+                        "tenantId": "tenant-2",
+                        "name": ""
+                    },
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
                     },
                     {
                         "tenantId": "tenant-4",
@@ -189,7 +262,139 @@
             }
         },
         {
-            "name": "getTenantsSortByNameASC",
+            "name": "sortByNameDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-5",
+                        "name": "Tenant C"
+                    },
+                    {
+                        "tenantId": "tenant-1",
+                        "name": "Tenant B"
+                    },
+                    {
+                        "tenantId": "tenant-3",
+                        "name": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=1&beforeId=tenant-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=1&afterId=tenant-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-4",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=1&beforeId=tenant-3&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-1",
+                        "name": "Tenant B"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=3&afterId=tenant-3&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-2",
+                        "name": ""
+                    },
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
+                    },
+                    {
+                        "tenantId": "tenant-4",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=1&beforeId=tenant-1&beforeValue=Tenant%20B"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-5",
+                        "name": "Tenant C"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=DESC&limit=2&afterId=tenant-5&afterValue=Tenant%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-1",
+                        "name": "Tenant B"
+                    },
+                    {
+                        "tenantId": "tenant-3",
+                        "name": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?sortBy=name&sortOrder=ASC"
@@ -202,12 +407,16 @@
                         "name": null
                     },
                     {
-                        "tenantId": "tenant-3",
-                        "name": ""
+                        "tenantId": "tenant-6",
+                        "name": null
                     },
                     {
                         "tenantId": "tenant-2",
-                        "name": "Tenant A"
+                        "name": ""
+                    },
+                    {
+                        "tenantId": "tenant-3",
+                        "name": ""
                     },
                     {
                         "tenantId": "tenant-1",
@@ -221,10 +430,10 @@
             }
         },
         {
-            "name": "getTenantsSortByNameASCLimit2",
+            "name": "sortByNameASCWithLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2"
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=1"
             },
             "expectedResponse": {
                 "statusCode": 200,
@@ -232,26 +441,74 @@
                     {
                         "tenantId": "tenant-4",
                         "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=1&beforeId=tenant-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-4",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=1&afterId=tenant-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2&beforeId=tenant-3&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
                     },
                     {
-                        "tenantId": "tenant-3",
+                        "tenantId": "tenant-2",
                         "name": ""
                     }
                 ]
             }
         },
         {
-            "name": "getTenantsSortByNameASCLimit2AfterIdAfterValue1",
+            "name": "sortByNameASCAfterValueEmptyString",
             "request": {
                 "method": "GET",
-                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2&afterId=tenant-3&afterValue="
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2&afterId=tenant-2&afterValue="
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
-                        "tenantId": "tenant-2",
-                        "name": "Tenant A"
+                        "tenantId": "tenant-3",
+                        "name": ""
                     },
                     {
                         "tenantId": "tenant-1",
@@ -261,7 +518,27 @@
             }
         },
         {
-            "name": "getTenantsSortByNameASCLimit2AfterIdAfterValue2",
+            "name": "sortByNameASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2&beforeId=tenant-5&beforeValue=Tenant%20C"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "tenantId": "tenant-3",
+                        "name": ""
+                    },
+                    {
+                        "tenantId": "tenant-1",
+                        "name": "Tenant B"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByNameASCValidAfterValue",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?sortBy=name&sortOrder=ASC&limit=2&afterId=tenant-1&afterValue=Tenant%20B"
@@ -277,27 +554,7 @@
             }
         },
         {
-            "name": "getTenantsSortByCreatedAtASCLimit2",
-            "request": {
-                "method": "GET",
-                "url": "/v1/tenants?sortBy=createdAt&sortOrder=ASC&limit=2"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "tenantId": "tenant-1",
-                        "name": "Tenant B"
-                    },
-                    {
-                        "tenantId": "tenant-2",
-                        "name": "Tenant A"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getTenantsLimit2",
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?limit=2"
@@ -311,13 +568,13 @@
                     },
                     {
                         "tenantId": "tenant-2",
-                        "name": "Tenant A"
+                        "name": ""
                     }
                 ]
             }
         },
         {
-            "name": "getTenantsLimit2AfterId1",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?limit=2&afterId=tenant-2"
@@ -337,7 +594,7 @@
             }
         },
         {
-            "name": "getTenantsLimit2AfterId2",
+            "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/tenants?limit=2&afterId=tenant-4"
@@ -348,6 +605,10 @@
                     {
                         "tenantId": "tenant-5",
                         "name": "Tenant C"
+                    },
+                    {
+                        "tenantId": "tenant-6",
+                        "name": null
                     }
                 ]
             }
@@ -397,6 +658,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/tenants/tenant-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteTenant6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/tenants/tenant-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/users-list.json
+++ b/tests/users-list.json
@@ -28,14 +28,14 @@
                 "url": "/v1/users",
                 "body": {
                     "userId": "user-2",
-                    "email": "user-a@warrant.dev"
+                    "email": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "userId": "user-2",
-                    "email": "user-a@warrant.dev"
+                    "email": ""
                 }
             }
         },
@@ -93,7 +93,7 @@
             }
         },
         {
-            "name": "getUsersSortByCreatedAtDESC",
+            "name": "sortByCreatedAtDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=createdAt&sortOrder=DESC"
@@ -115,7 +115,7 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     },
                     {
                         "userId": "user-1",
@@ -125,7 +125,7 @@
             }
         },
         {
-            "name": "getUsersSortByCreatedAtASC",
+            "name": "sortByCreatedAtASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=createdAt&sortOrder=ASC"
@@ -139,7 +139,7 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     },
                     {
                         "userId": "user-3",
@@ -157,7 +157,7 @@
             }
         },
         {
-            "name": "getUsersSortByEmailDESC",
+            "name": "sortByEmailDESC",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=email&sortOrder=DESC"
@@ -175,7 +175,7 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     },
                     {
                         "userId": "user-4",
@@ -189,7 +189,51 @@
             }
         },
         {
-            "name": "getUsersSortByEmailASC",
+            "name": "sortByEmailDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-5",
+                        "email": "user-c@warrant.dev"
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    },
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3&afterId=user-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASC",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=email&sortOrder=ASC"
@@ -207,7 +251,7 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     },
                     {
                         "userId": "user-1",
@@ -221,10 +265,114 @@
             }
         },
         {
-            "name": "getUsersSortByEmailASCLimit2",
+            "name": "sortByEmailASCWithLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2"
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&afterId=user-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&beforeId=user-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCAfterValueNullNextValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-4"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-1&afterValue=user-b%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-5",
+                        "email": "user-c@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-5&beforeValue=user-c%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-2&beforeValue="
             },
             "expectedResponse": {
                 "statusCode": 200,
@@ -241,43 +389,7 @@
             }
         },
         {
-            "name": "getUsersSortByEmailASCLimit2AfterIdAfterValue1",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-3&afterValue="
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-2",
-                        "email": "user-a@warrant.dev"
-                    },
-                    {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getUsersSortByEmailASCLimit2AfterIdAfterValue2",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-1&afterValue=user-b%40warrant.dev"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-5",
-                        "email": "user-c@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "getUsersSortByCreatedAtASCLimit2",
+            "name": "sortByCreatedAtASCWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=createdAt&sortOrder=ASC&limit=2"
@@ -291,13 +403,13 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     }
                 ]
             }
         },
         {
-            "name": "getUsersLimit2",
+            "name": "noSortWithLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?limit=2"
@@ -311,13 +423,13 @@
                     },
                     {
                         "userId": "user-2",
-                        "email": "user-a@warrant.dev"
+                        "email": ""
                     }
                 ]
             }
         },
         {
-            "name": "getUsersLimit2AfterId1",
+            "name": "noSortWithLimitAndValidAfterId",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?limit=2&afterId=user-2"
@@ -337,7 +449,7 @@
             }
         },
         {
-            "name": "getUsersLimit2AfterId2",
+            "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?limit=2&afterId=user-4"

--- a/tests/users-list.json
+++ b/tests/users-list.json
@@ -213,7 +213,7 @@
             }
         },
         {
-            "name": "sortByEmailAfterValueEmptyString",
+            "name": "sortByEmailDESCAfterValueEmptyString",
             "request": {
                 "method": "GET",
                 "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3&afterId=user-2&afterValue="

--- a/tests/users-list.json
+++ b/tests/users-list.json
@@ -45,8 +45,7 @@
                 "method": "POST",
                 "url": "/v1/users",
                 "body": {
-                    "userId": "user-3",
-                    "email": null
+                    "userId": "user-3"
                 }
             },
             "expectedResponse": {
@@ -63,14 +62,15 @@
                 "method": "POST",
                 "url": "/v1/users",
                 "body": {
-                    "userId": "user-4"
+                    "userId": "user-4",
+                    "email": "user-c@warrant.dev"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "userId": "user-4",
-                    "email": null
+                    "email": "user-c@warrant.dev"
                 }
             }
         },
@@ -81,14 +81,31 @@
                 "url": "/v1/users",
                 "body": {
                     "userId": "user-5",
-                    "email": "user-c@warrant.dev"
+                    "email": ""
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "userId": "user-5",
-                    "email": "user-c@warrant.dev"
+                    "email": ""
+                }
+            }
+        },
+        {
+            "name": "createUser6",
+            "request": {
+                "method": "POST",
+                "url": "/v1/users",
+                "body": {
+                    "userId": "user-6"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "userId": "user-6",
+                    "email": null
                 }
             }
         },
@@ -102,12 +119,16 @@
                 "statusCode": 200,
                 "body": [
                     {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
                         "userId": "user-5",
-                        "email": "user-c@warrant.dev"
+                        "email": ""
                     },
                     {
                         "userId": "user-4",
-                        "email": null
+                        "email": "user-c@warrant.dev"
                     },
                     {
                         "userId": "user-3",
@@ -120,6 +141,30 @@
                     {
                         "userId": "user-1",
                         "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByCreatedAtDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=createdAt&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
                     }
                 ]
             }
@@ -147,242 +192,14 @@
                     },
                     {
                         "userId": "user-4",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-5",
-                        "email": "user-c@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailDESC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=DESC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-5",
                         "email": "user-c@warrant.dev"
                     },
                     {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    },
-                    {
-                        "userId": "user-2",
-                        "email": ""
-                    },
-                    {
-                        "userId": "user-4",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailDESCWithLimit",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
                         "userId": "user-5",
-                        "email": "user-c@warrant.dev"
-                    },
-                    {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    },
-                    {
-                        "userId": "user-2",
-                        "email": ""
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailDESCAfterValueEmptyString",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3&afterId=user-2&afterValue="
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-4",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASC",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-4",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-2",
                         "email": ""
                     },
                     {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    },
-                    {
-                        "userId": "user-5",
-                        "email": "user-c@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCWithLimit",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCAfterValueNull",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&afterId=user-3"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-4",
-                        "email": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCBeforeValueNull",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&beforeId=user-4"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCAfterValueNullNextValueEmptyString",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-4"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-2",
-                        "email": ""
-                    },
-                    {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCValidAfterValue",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-1&afterValue=user-b%40warrant.dev"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-5",
-                        "email": "user-c@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCValidBeforeValue",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-5&beforeValue=user-c%40warrant.dev"
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-2",
-                        "email": ""
-                    },
-                    {
-                        "userId": "user-1",
-                        "email": "user-b@warrant.dev"
-                    }
-                ]
-            }
-        },
-        {
-            "name": "sortByEmailASCBeforeValueEmptyString",
-            "request": {
-                "method": "GET",
-                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-2&beforeValue="
-            },
-            "expectedResponse": {
-                "statusCode": 200,
-                "body": [
-                    {
-                        "userId": "user-3",
-                        "email": null
-                    },
-                    {
-                        "userId": "user-4",
+                        "userId": "user-6",
                         "email": null
                     }
                 ]
@@ -404,6 +221,338 @@
                     {
                         "userId": "user-2",
                         "email": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    },
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    },
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=1&beforeId=user-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=1&afterId=user-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=1&beforeId=user-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=3&afterId=user-5&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=1&beforeId=user-1&beforeValue=user-b%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailDESCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=DESC&limit=2&afterId=user-4&afterValue=user-c%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    },
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASC",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    },
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCWithLimit",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCBeforeValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&beforeId=user-6"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-3",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCAfterValueNull",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=1&afterId=user-3"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCBeforeValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-5&beforeValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-6",
+                        "email": null
+                    },
+                    {
+                        "userId": "user-2",
+                        "email": ""
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCAfterValueEmptyString",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-2&afterValue="
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCValidBeforeValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&beforeId=user-4&beforeValue=user-c%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-5",
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-1",
+                        "email": "user-b@warrant.dev"
+                    }
+                ]
+            }
+        },
+        {
+            "name": "sortByEmailASCValidAfterValue",
+            "request": {
+                "method": "GET",
+                "url": "/v1/users?sortBy=email&sortOrder=ASC&limit=2&afterId=user-1&afterValue=user-b%40warrant.dev"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": [
+                    {
+                        "userId": "user-4",
+                        "email": "user-c@warrant.dev"
                     }
                 ]
             }
@@ -443,7 +592,7 @@
                     },
                     {
                         "userId": "user-4",
-                        "email": null
+                        "email": "user-c@warrant.dev"
                     }
                 ]
             }
@@ -452,14 +601,18 @@
             "name": "noSortResultSmallerThanLimit",
             "request": {
                 "method": "GET",
-                "url": "/v1/users?limit=2&afterId=user-4"
+                "url": "/v1/users?limit=3&afterId=user-4"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
                         "userId": "user-5",
-                        "email": "user-c@warrant.dev"
+                        "email": ""
+                    },
+                    {
+                        "userId": "user-6",
+                        "email": null
                     }
                 ]
             }
@@ -509,6 +662,16 @@
             "request": {
                 "method": "DELETE",
                 "url": "/v1/users/user-5"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUser6",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/users/user-6"
             },
             "expectedResponse": {
                 "statusCode": 200

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -120,7 +120,7 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-5"
+                            "resourceId": "user-6"
                         }
                     ],
                     "lastId": "{{ listResourceEventsFilterByType.lastId }}"
@@ -157,6 +157,12 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
+                            "resourceId": "user-6"
+                        },
+                        {
+                            "type": "deleted",
+                            "source": "api",
+                            "resourceType": "user",
                             "resourceId": "user-5"
                         },
                         {
@@ -164,12 +170,6 @@
                             "source": "api",
                             "resourceType": "user",
                             "resourceId": "user-4"
-                        },
-                        {
-                            "type": "deleted",
-                            "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-3"
                         }
                     ],
                     "lastId": "{{ listResourceEventsFilterByResourceType.lastId }}"


### PR DESCRIPTION
## Describe your changes
This PR updates all resource list endpoints to better support pagination on nullable columns. This includes cases where the before/after value is `NULL` and cases where the the before/after value is an empty string.

## Issue number and link (if applicable)
N/A