### PR TITLE
Add support for sql 'reader' dbs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -79,24 +79,30 @@ type DatastoreConfig struct {
 }
 
 type MySQLConfig struct {
-	Username           string `mapstructure:"username"`
-	Password           string `mapstructure:"password"`
-	Hostname           string `mapstructure:"hostname"`
-	Database           string `mapstructure:"database"`
-	MigrationSource    string `mapstructure:"migrationSource"`
-	MaxIdleConnections int    `mapstructure:"maxIdleConnections"`
-	MaxOpenConnections int    `mapstructure:"maxOpenConnections"`
+	Username                 string `mapstructure:"username"`
+	Password                 string `mapstructure:"password"`
+	Hostname                 string `mapstructure:"hostname"`
+	Database                 string `mapstructure:"database"`
+	MigrationSource          string `mapstructure:"migrationSource"`
+	MaxIdleConnections       int    `mapstructure:"maxIdleConnections"`
+	MaxOpenConnections       int    `mapstructure:"maxOpenConnections"`
+	ReaderHostname           string `mapstructure:"readerHostname"`
+	ReaderMaxIdleConnections int    `mapstructure:"readerMaxIdleConnections"`
+	ReaderMaxOpenConnections int    `mapstructure:"readerMaxOpenConnections"`
 }
 
 type PostgresConfig struct {
-	Username           string `mapstructure:"username"`
-	Password           string `mapstructure:"password"`
-	Hostname           string `mapstructure:"hostname"`
-	Database           string `mapstructure:"database"`
-	SSLMode            string `mapstructure:"sslmode"`
-	MigrationSource    string `mapstructure:"migrationSource"`
-	MaxIdleConnections int    `mapstructure:"maxIdleConnections"`
-	MaxOpenConnections int    `mapstructure:"maxOpenConnections"`
+	Username                 string `mapstructure:"username"`
+	Password                 string `mapstructure:"password"`
+	Hostname                 string `mapstructure:"hostname"`
+	Database                 string `mapstructure:"database"`
+	SSLMode                  string `mapstructure:"sslmode"`
+	MigrationSource          string `mapstructure:"migrationSource"`
+	MaxIdleConnections       int    `mapstructure:"maxIdleConnections"`
+	MaxOpenConnections       int    `mapstructure:"maxOpenConnections"`
+	ReaderHostname           string `mapstructure:"readerHostname"`
+	ReaderMaxIdleConnections int    `mapstructure:"readerMaxIdleConnections"`
+	ReaderMaxOpenConnections int    `mapstructure:"readerMaxOpenConnections"`
 }
 
 type SQLiteConfig struct {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,6 +13,7 @@ type Database interface {
 	Connect(ctx context.Context) error
 	Migrate(ctx context.Context, toVersion uint) error
 	Ping(ctx context.Context) error
+	WithinConsistentRead(ctx context.Context, connCallback func(ctx context.Context) error) error
 	WithinTransaction(ctx context.Context, txCallback func(ctx context.Context) error) error
 	DbHandler(ctx context.Context) interface{}
 }

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -143,12 +143,15 @@ func (ds MySQL) Migrate(ctx context.Context, toVersion uint) error {
 func (ds MySQL) Ping(ctx context.Context) error {
 	err := ds.Writer.PingContext(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error while attempting to ping mysql database")
 	}
 	if ds.Reader != nil {
 		err = ds.Reader.PingContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, "Error while attempting to ping mysql reader")
+		}
 	}
-	return err
+	return nil
 }
 
 func (ds MySQL) DbHandler(ctx context.Context) interface{} {

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -23,7 +23,7 @@ type MySQL struct {
 
 func NewMySQL(config config.MySQLConfig) *MySQL {
 	return &MySQL{
-		SQL:    NewSQL(nil, config.Hostname, config.Database),
+		SQL:    NewSQL(nil, nil, config.Hostname, config.ReaderHostname, config.Database),
 		Config: config,
 	}
 }
@@ -72,8 +72,34 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	// map struct attributes to db column names
 	db.Mapper = reflectx.NewMapperFunc("mysql", func(s string) string { return s })
 
-	ds.DB = db
+	ds.Writer = db
 	log.Info().Msgf("Connected to mysql database %s", ds.Config.Database)
+
+	// connect to reader if provided
+	if ds.Config.ReaderHostname != "" {
+		reader, err := sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.ReaderHostname, ds.Config.Database))
+		if err != nil {
+			return errors.Wrap(err, "Unable to establish connection to mysql reader. Shutting down server.")
+		}
+
+		err = reader.PingContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, "Unable to ping mysql reader. Shutting down server.")
+		}
+
+		if ds.Config.ReaderMaxIdleConnections != 0 {
+			reader.SetMaxIdleConns(ds.Config.ReaderMaxIdleConnections)
+		}
+
+		if ds.Config.ReaderMaxOpenConnections != 0 {
+			reader.SetMaxOpenConns(ds.Config.ReaderMaxOpenConnections)
+		}
+		// map struct attributes to db column names
+		reader.Mapper = reflectx.NewMapperFunc("mysql", func(s string) string { return s })
+		ds.Reader = reader
+		log.Info().Msgf("Connected to mysql reader database %s", ds.Config.Database)
+	}
+
 	return nil
 }
 
@@ -115,7 +141,14 @@ func (ds MySQL) Migrate(ctx context.Context, toVersion uint) error {
 }
 
 func (ds MySQL) Ping(ctx context.Context) error {
-	return ds.DB.PingContext(ctx)
+	err := ds.Writer.PingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if ds.Reader != nil {
+		err = ds.Reader.PingContext(ctx)
+	}
+	return err
 }
 
 func (ds MySQL) DbHandler(ctx context.Context) interface{} {

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -25,7 +25,7 @@ type Postgres struct {
 
 func NewPostgres(config config.PostgresConfig) *Postgres {
 	return &Postgres{
-		SQL:    NewSQL(nil, config.Hostname, config.Database),
+		SQL:    NewSQL(nil, nil, config.Hostname, config.ReaderHostname, config.Database),
 		Config: config,
 	}
 }
@@ -78,8 +78,36 @@ func (ds *Postgres) Connect(ctx context.Context) error {
 	// map struct attributes to db column names
 	db.Mapper = reflectx.NewMapperFunc("postgres", func(s string) string { return s })
 
-	ds.DB = db
+	ds.Writer = db
 	log.Info().Msgf("Connected to postgres database %s", ds.Config.Database)
+
+	// connect to reader if provided
+	if ds.Config.ReaderHostname != "" {
+		reader, err := sqlx.Open("postgres", fmt.Sprintf("postgres://%s@%s/%s?sslmode=%s", usernamePassword, ds.Config.ReaderHostname, ds.Config.Database, ds.Config.SSLMode))
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Unable to establish connection to postgres reader %s. Shutting down server.", ds.Config.Database))
+		}
+
+		err = reader.PingContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("Unable to ping postgres reader %s. Shutting down server.", ds.Config.Database))
+		}
+
+		if ds.Config.ReaderMaxIdleConnections != 0 {
+			reader.SetMaxIdleConns(ds.Config.ReaderMaxIdleConnections)
+		}
+
+		if ds.Config.ReaderMaxOpenConnections != 0 {
+			reader.SetMaxOpenConns(ds.Config.ReaderMaxOpenConnections)
+		}
+
+		// map struct attributes to db column names
+		reader.Mapper = reflectx.NewMapperFunc("postgres", func(s string) string { return s })
+
+		ds.Reader = reader
+		log.Info().Msgf("Connected to postgres reader %s", ds.Config.Database)
+	}
+
 	return nil
 }
 
@@ -122,7 +150,14 @@ func (ds Postgres) Migrate(ctx context.Context, toVersion uint) error {
 }
 
 func (ds Postgres) Ping(ctx context.Context) error {
-	return ds.DB.PingContext(ctx)
+	err := ds.Writer.PingContext(ctx)
+	if err != nil {
+		return err
+	}
+	if ds.Reader != nil {
+		err = ds.Reader.PingContext(ctx)
+	}
+	return err
 }
 
 func (ds Postgres) DbHandler(ctx context.Context) interface{} {

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -152,12 +152,15 @@ func (ds Postgres) Migrate(ctx context.Context, toVersion uint) error {
 func (ds Postgres) Ping(ctx context.Context) error {
 	err := ds.Writer.PingContext(ctx)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Error while attempting to ping postgres database")
 	}
 	if ds.Reader != nil {
 		err = ds.Reader.PingContext(ctx)
+		if err != nil {
+			return errors.Wrap(err, "Error while attempting to ping postgres reader")
+		}
 	}
-	return err
+	return nil
 }
 
 func (ds Postgres) DbHandler(ctx context.Context) interface{} {


### PR DESCRIPTION
## Describe your changes
- Allow for configuration of 'reader' sql dbs in addition to primary 'writer'
- Expose simple api for repos/services to make use of read-only conns

## Issue number and link (if applicable)
https://github.com/warrant-dev/warrant/issues/162
