### PR TITLE
Fix typo in `object` and `objecttype` package list middleware error messages

### DIFF
--- a/pkg/authz/object/list.go
+++ b/pkg/authz/object/list.go
@@ -22,7 +22,7 @@ func (parser ObjectListParamParser) ParseValue(val string, sortBy string) (inter
 	case "createdAt":
 		afterValue, err := time.Parse(time.RFC3339, val)
 		if err != nil || afterValue.Equal(time.Time{}) {
-			return nil, fmt.Errorf("must be a valid time in the %s", time.RFC3339)
+			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
 		return &afterValue, nil

--- a/pkg/authz/objecttype/list.go
+++ b/pkg/authz/objecttype/list.go
@@ -23,7 +23,7 @@ func (parser ObjectTypeListParamParser) ParseValue(val string, sortBy string) (i
 	case "createdAt":
 		afterValue, err := time.Parse(time.RFC3339, val)
 		if err != nil || afterValue.Equal(time.Time{}) {
-			return nil, fmt.Errorf("must be a valid time in the %s", time.RFC3339)
+			return nil, fmt.Errorf("must be a valid time in the format %s", time.RFC3339)
 		}
 
 		return &afterValue, nil


### PR DESCRIPTION
## Describe your changes
This PR fixes typos in the `object` and `objecttype` packages' list middleware

## Issue number and link (if applicable)
N/A