### PR TITLE
Change event svc read methods to useConsistentRead if syncEvents is false

### DIFF
--- a/pkg/authz/wookie/service.go
+++ b/pkg/authz/wookie/service.go
@@ -108,7 +108,7 @@ func (svc WookieService) WookieSafeRead(ctx context.Context, readFunc func(wkCtx
 
 	// Otherwise, compare client wookie to a reader's latest wookie to see if we can use it
 	var latestWookieToReturn *Token
-	e := svc.Env().DB().WithinConsistentRead(ctx, func(connCtx context.Context) error {
+	e := svc.Env().DB().ReplicaSafeRead(ctx, func(connCtx context.Context) error {
 		unsafe := false
 
 		// First, get the reader's latest wookie

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -13,7 +13,7 @@ type Database interface {
 	Connect(ctx context.Context) error
 	Migrate(ctx context.Context, toVersion uint) error
 	Ping(ctx context.Context) error
-	WithinConsistentRead(ctx context.Context, connCallback func(ctx context.Context) error) error
+	ReplicaSafeRead(ctx context.Context, connCallback func(ctx context.Context) error) error
 	WithinTransaction(ctx context.Context, txCallback func(ctx context.Context) error) error
 	DbHandler(ctx context.Context) interface{}
 }

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -221,7 +221,7 @@ func NewSQL(writer *sqlx.DB, reader *sqlx.DB, writerHostname string, readerHostn
 }
 
 // Execute connCallback() within the context of a single connection to a 'reader' db instance if present
-func (ds SQL) WithinConsistentRead(ctx context.Context, connCallback func(connCtx context.Context) error) error {
+func (ds SQL) ReplicaSafeRead(ctx context.Context, connCallback func(connCtx context.Context) error) error {
 	_, hasReadConn := ctx.Value(newReadConnKey(ds.DatabaseName)).(*ReadSqlConn)
 	_, hasTx := ctx.Value(newTxKey(ds.DatabaseName)).(*SqlTx)
 

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -150,9 +150,21 @@ func (svc EventService) TrackResourceEvents(ctx context.Context, resourceEventSp
 
 func (svc EventService) ListResourceEvents(ctx context.Context, listParams ListResourceEventParams) ([]ResourceEventSpec, string, error) {
 	resourceEventSpecs := make([]ResourceEventSpec, 0)
-	resourceEvents, lastId, err := svc.Repository.ListResourceEvents(ctx, listParams)
+
+	var resourceEvents []ResourceEventModel
+	var lastId string
+	var err error
+	if !svc.synchronizeEvents {
+		err = svc.Env().EventDB().WithinConsistentRead(ctx, func(connCtx context.Context) error {
+			resourceEvents, lastId, err = svc.Repository.ListResourceEvents(connCtx, listParams)
+			return err
+		})
+	} else {
+		resourceEvents, lastId, err = svc.Repository.ListResourceEvents(ctx, listParams)
+	}
+
 	if err != nil {
-		return resourceEventSpecs, lastId, err
+		return resourceEventSpecs, "", err
 	}
 
 	for _, resourceEvent := range resourceEvents {
@@ -293,9 +305,21 @@ func (svc EventService) TrackAccessEvents(ctx context.Context, accessEventSpecs 
 
 func (svc EventService) ListAccessEvents(ctx context.Context, listParams ListAccessEventParams) ([]AccessEventSpec, string, error) {
 	accessEventSpecs := make([]AccessEventSpec, 0)
-	accessEvents, lastId, err := svc.Repository.ListAccessEvents(ctx, listParams)
+
+	var accessEvents []AccessEventModel
+	var lastId string
+	var err error
+	if !svc.synchronizeEvents {
+		err = svc.Env().EventDB().WithinConsistentRead(ctx, func(connCtx context.Context) error {
+			accessEvents, lastId, err = svc.Repository.ListAccessEvents(connCtx, listParams)
+			return err
+		})
+	} else {
+		accessEvents, lastId, err = svc.Repository.ListAccessEvents(ctx, listParams)
+	}
+
 	if err != nil {
-		return accessEventSpecs, lastId, err
+		return accessEventSpecs, "", err
 	}
 
 	for _, accessEvent := range accessEvents {

--- a/pkg/event/service.go
+++ b/pkg/event/service.go
@@ -155,7 +155,7 @@ func (svc EventService) ListResourceEvents(ctx context.Context, listParams ListR
 	var lastId string
 	var err error
 	if !svc.synchronizeEvents {
-		err = svc.Env().EventDB().WithinConsistentRead(ctx, func(connCtx context.Context) error {
+		err = svc.Env().EventDB().ReplicaSafeRead(ctx, func(connCtx context.Context) error {
 			resourceEvents, lastId, err = svc.Repository.ListResourceEvents(connCtx, listParams)
 			return err
 		})
@@ -310,7 +310,7 @@ func (svc EventService) ListAccessEvents(ctx context.Context, listParams ListAcc
 	var lastId string
 	var err error
 	if !svc.synchronizeEvents {
-		err = svc.Env().EventDB().WithinConsistentRead(ctx, func(connCtx context.Context) error {
+		err = svc.Env().EventDB().ReplicaSafeRead(ctx, func(connCtx context.Context) error {
 			accessEvents, lastId, err = svc.Repository.ListAccessEvents(connCtx, listParams)
 			return err
 		})


### PR DESCRIPTION
## Describe your changes
- Change event service read methods for access and resource events to use the db's consistentRead method if the syncEvents config is 'false'

## Issue number and link (if applicable)
