### PR TITLE
Change SQLRepository back to holding ref to *SQL handle

### DIFF
--- a/pkg/authz/feature/mysql.go
+++ b/pkg/authz/feature/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO feature (
@@ -61,7 +61,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -87,7 +87,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByFeatureId(ctx context.Context, featureId string) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -240,7 +240,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&features,
 		query,
@@ -263,7 +263,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByFeatureId(ctx context.Context, featureId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature
@@ -286,7 +286,7 @@ func (repo MySQLRepository) UpdateByFeatureId(ctx context.Context, featureId str
 }
 
 func (repo MySQLRepository) DeleteByFeatureId(ctx context.Context, featureId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature

--- a/pkg/authz/feature/postgres.go
+++ b/pkg/authz/feature/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newFeatureId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newFeatureId,
 		`
@@ -60,7 +60,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -86,7 +86,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByFeatureId(ctx context.Context, featureId string) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -248,7 +248,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&features,
 		query,
@@ -271,7 +271,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByFeatureId(ctx context.Context, featureId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature
@@ -294,7 +294,7 @@ func (repo PostgresRepository) UpdateByFeatureId(ctx context.Context, featureId 
 }
 
 func (repo PostgresRepository) DeleteByFeatureId(ctx context.Context, featureId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature

--- a/pkg/authz/feature/sqlite.go
+++ b/pkg/authz/feature/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newFeatureId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newFeatureId,
 		`
@@ -67,7 +67,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -93,7 +93,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByFeatureId(ctx context.Context, featureId string) (Model, error) {
 	var feature Feature
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&feature,
 		`
@@ -246,7 +246,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&features,
 		query,
@@ -269,7 +269,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByFeatureId(ctx context.Context, featureId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature
@@ -294,7 +294,7 @@ func (repo SQLiteRepository) UpdateByFeatureId(ctx context.Context, featureId st
 }
 
 func (repo SQLiteRepository) DeleteByFeatureId(ctx context.Context, featureId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE feature

--- a/pkg/authz/object/mysql.go
+++ b/pkg/authz/object/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO object (
@@ -50,7 +50,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -76,7 +76,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -236,7 +236,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objects,
 		query,
@@ -259,7 +259,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 }
 
 func (repo MySQLRepository) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE object

--- a/pkg/authz/object/postgres.go
+++ b/pkg/authz/object/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newObjectId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newObjectId,
 		`
@@ -49,7 +49,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -75,7 +75,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -243,7 +243,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 			replacements = append(replacements, listParams.Limit)
 		}
 	}
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objects,
 		query,
@@ -266,7 +266,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 }
 
 func (repo PostgresRepository) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE object

--- a/pkg/authz/object/sqlite.go
+++ b/pkg/authz/object/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newObjectId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newObjectId,
 		`
@@ -54,7 +54,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -80,7 +80,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (Model, error) {
 	var object Object
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&object,
 		`
@@ -242,7 +242,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objects,
 		query,
@@ -265,7 +265,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 }
 
 func (repo SQLiteRepository) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE object

--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO objectType (
@@ -52,7 +52,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -78,7 +78,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByTypeId(ctx context.Context, typeId string) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -231,7 +231,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objectTypes,
 		query,
@@ -254,7 +254,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByTypeId(ctx context.Context, typeId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE objectType
@@ -275,7 +275,7 @@ func (repo MySQLRepository) UpdateByTypeId(ctx context.Context, typeId string, m
 }
 
 func (repo MySQLRepository) DeleteByTypeId(ctx context.Context, typeId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE objectType

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newObjectTypeId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newObjectTypeId,
 		`
@@ -51,7 +51,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -77,7 +77,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByTypeId(ctx context.Context, typeId string) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -239,7 +239,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objectTypes,
 		query,
@@ -262,7 +262,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByTypeId(ctx context.Context, typeId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE object_type
@@ -283,7 +283,7 @@ func (repo PostgresRepository) UpdateByTypeId(ctx context.Context, typeId string
 }
 
 func (repo PostgresRepository) DeleteByTypeId(ctx context.Context, typeId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE object_type

--- a/pkg/authz/objecttype/sqlite.go
+++ b/pkg/authz/objecttype/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newObjectTypeId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newObjectTypeId,
 		`
@@ -56,7 +56,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -82,7 +82,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByTypeId(ctx context.Context, typeId string) (Model, error) {
 	var objectType ObjectType
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&objectType,
 		`
@@ -235,7 +235,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&objectTypes,
 		query,
@@ -258,7 +258,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByTypeId(ctx context.Context, typeId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE objectType
@@ -281,7 +281,7 @@ func (repo SQLiteRepository) UpdateByTypeId(ctx context.Context, typeId string, 
 }
 
 func (repo SQLiteRepository) DeleteByTypeId(ctx context.Context, typeId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE objectType

--- a/pkg/authz/permission/mysql.go
+++ b/pkg/authz/permission/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO permission (
@@ -61,7 +61,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -87,7 +87,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByPermissionId(ctx context.Context, permissionId string) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -240,7 +240,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&permissions,
 		query,
@@ -263,7 +263,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByPermissionId(ctx context.Context, permissionId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission
@@ -286,7 +286,7 @@ func (repo MySQLRepository) UpdateByPermissionId(ctx context.Context, permission
 }
 
 func (repo MySQLRepository) DeleteByPermissionId(ctx context.Context, permissionId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission

--- a/pkg/authz/permission/postgres.go
+++ b/pkg/authz/permission/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newPermissionId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newPermissionId,
 		`
@@ -60,7 +60,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -86,7 +86,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByPermissionId(ctx context.Context, permissionId string) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -248,7 +248,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&permissions,
 		query,
@@ -271,7 +271,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByPermissionId(ctx context.Context, permissionId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission
@@ -294,7 +294,7 @@ func (repo PostgresRepository) UpdateByPermissionId(ctx context.Context, permiss
 }
 
 func (repo PostgresRepository) DeleteByPermissionId(ctx context.Context, permissionId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission

--- a/pkg/authz/permission/sqlite.go
+++ b/pkg/authz/permission/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newPermissionId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newPermissionId,
 		`
@@ -65,7 +65,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -91,7 +91,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByPermissionId(ctx context.Context, permissionId string) (Model, error) {
 	var permission Permission
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&permission,
 		`
@@ -244,7 +244,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&permissions,
 		query,
@@ -267,7 +267,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByPermissionId(ctx context.Context, permissionId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission
@@ -292,7 +292,7 @@ func (repo SQLiteRepository) UpdateByPermissionId(ctx context.Context, permissio
 }
 
 func (repo SQLiteRepository) DeleteByPermissionId(ctx context.Context, permissionId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE permission

--- a/pkg/authz/pricingtier/mysql.go
+++ b/pkg/authz/pricingtier/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO pricingTier (
@@ -61,7 +61,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -87,7 +87,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByPricingTierId(ctx context.Context, pricingTierId string) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -240,7 +240,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&pricingTiers,
 		query,
@@ -263,7 +263,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByPricingTierId(ctx context.Context, pricingTierId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricingTier
@@ -286,7 +286,7 @@ func (repo MySQLRepository) UpdateByPricingTierId(ctx context.Context, pricingTi
 }
 
 func (repo MySQLRepository) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricingTier

--- a/pkg/authz/pricingtier/postgres.go
+++ b/pkg/authz/pricingtier/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newPricingTierId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newPricingTierId,
 		`
@@ -60,7 +60,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -86,7 +86,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByPricingTierId(ctx context.Context, pricingTierId string) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -248,7 +248,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&pricingTiers,
 		query,
@@ -271,7 +271,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByPricingTierId(ctx context.Context, pricingTierId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricing_tier
@@ -294,7 +294,7 @@ func (repo PostgresRepository) UpdateByPricingTierId(ctx context.Context, pricin
 }
 
 func (repo PostgresRepository) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricing_tier

--- a/pkg/authz/pricingtier/sqlite.go
+++ b/pkg/authz/pricingtier/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newPricingTierId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newPricingTierId,
 		`
@@ -65,7 +65,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -91,7 +91,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByPricingTierId(ctx context.Context, pricingTierId string) (Model, error) {
 	var pricingTier PricingTier
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&pricingTier,
 		`
@@ -244,7 +244,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&pricingTiers,
 		query,
@@ -267,7 +267,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByPricingTierId(ctx context.Context, pricingTierId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricingTier
@@ -292,7 +292,7 @@ func (repo SQLiteRepository) UpdateByPricingTierId(ctx context.Context, pricingT
 }
 
 func (repo SQLiteRepository) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE pricingTier

--- a/pkg/authz/role/mysql.go
+++ b/pkg/authz/role/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, role Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO role (
@@ -61,7 +61,7 @@ func (repo MySQLRepository) Create(ctx context.Context, role Model) (int64, erro
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -87,7 +87,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByRoleId(ctx context.Context, roleId string) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -240,7 +240,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&roles,
 		query,
@@ -263,7 +263,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByRoleId(ctx context.Context, roleId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role
@@ -286,7 +286,7 @@ func (repo MySQLRepository) UpdateByRoleId(ctx context.Context, roleId string, m
 }
 
 func (repo MySQLRepository) DeleteByRoleId(ctx context.Context, roleId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role

--- a/pkg/authz/role/postgres.go
+++ b/pkg/authz/role/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newRoleId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newRoleId,
 		`
@@ -60,7 +60,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -86,7 +86,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByRoleId(ctx context.Context, roleId string) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -248,7 +248,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&roles,
 		query,
@@ -271,7 +271,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByRoleId(ctx context.Context, roleId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role
@@ -294,7 +294,7 @@ func (repo PostgresRepository) UpdateByRoleId(ctx context.Context, roleId string
 }
 
 func (repo PostgresRepository) DeleteByRoleId(ctx context.Context, roleId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role

--- a/pkg/authz/role/sqlite.go
+++ b/pkg/authz/role/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newRoleId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newRoleId,
 		`
@@ -65,7 +65,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -91,7 +91,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByRoleId(ctx context.Context, roleId string) (Model, error) {
 	var role Role
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&role,
 		`
@@ -244,7 +244,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&roles,
 		query,
@@ -267,7 +267,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByRoleId(ctx context.Context, roleId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role
@@ -292,7 +292,7 @@ func (repo SQLiteRepository) UpdateByRoleId(ctx context.Context, roleId string, 
 }
 
 func (repo SQLiteRepository) DeleteByRoleId(ctx context.Context, roleId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE role

--- a/pkg/authz/tenant/mysql.go
+++ b/pkg/authz/tenant/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO tenant (
@@ -57,7 +57,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -83,7 +83,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByTenantId(ctx context.Context, tenantId string) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -237,7 +237,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&tenants,
 		query,
@@ -260,7 +260,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByTenantId(ctx context.Context, tenantId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant
@@ -281,7 +281,7 @@ func (repo MySQLRepository) UpdateByTenantId(ctx context.Context, tenantId strin
 }
 
 func (repo MySQLRepository) DeleteByTenantId(ctx context.Context, tenantId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant

--- a/pkg/authz/tenant/postgres.go
+++ b/pkg/authz/tenant/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newTenantId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newTenantId,
 		`
@@ -56,7 +56,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -82,7 +82,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByTenantId(ctx context.Context, tenantId string) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -245,7 +245,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&tenants,
 		query,
@@ -268,7 +268,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByTenantId(ctx context.Context, tenantId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant
@@ -289,7 +289,7 @@ func (repo PostgresRepository) UpdateByTenantId(ctx context.Context, tenantId st
 }
 
 func (repo PostgresRepository) DeleteByTenantId(ctx context.Context, tenantId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant

--- a/pkg/authz/tenant/sqlite.go
+++ b/pkg/authz/tenant/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newTenantId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newTenantId,
 		`
@@ -61,7 +61,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -87,7 +87,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByTenantId(ctx context.Context, tenantId string) (Model, error) {
 	var tenant Tenant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&tenant,
 		`
@@ -241,7 +241,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&tenants,
 		query,
@@ -264,7 +264,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByTenantId(ctx context.Context, tenantId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant
@@ -287,7 +287,7 @@ func (repo SQLiteRepository) UpdateByTenantId(ctx context.Context, tenantId stri
 }
 
 func (repo SQLiteRepository) DeleteByTenantId(ctx context.Context, tenantId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE tenant

--- a/pkg/authz/user/mysql.go
+++ b/pkg/authz/user/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO user (
@@ -56,7 +56,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -82,7 +82,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetByUserId(ctx context.Context, userId string) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -235,7 +235,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&users,
 		query,
@@ -258,7 +258,7 @@ func (repo MySQLRepository) List(ctx context.Context, listParams service.ListPar
 }
 
 func (repo MySQLRepository) UpdateByUserId(ctx context.Context, userId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE user
@@ -279,7 +279,7 @@ func (repo MySQLRepository) UpdateByUserId(ctx context.Context, userId string, m
 }
 
 func (repo MySQLRepository) DeleteByUserId(ctx context.Context, userId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE user

--- a/pkg/authz/user/postgres.go
+++ b/pkg/authz/user/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newUserId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newUserId,
 		`
@@ -55,7 +55,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -81,7 +81,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetByUserId(ctx context.Context, userId string) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -243,7 +243,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&users,
 		query,
@@ -266,7 +266,7 @@ func (repo PostgresRepository) List(ctx context.Context, listParams service.List
 }
 
 func (repo PostgresRepository) UpdateByUserId(ctx context.Context, userId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE "user"
@@ -287,7 +287,7 @@ func (repo PostgresRepository) UpdateByUserId(ctx context.Context, userId string
 }
 
 func (repo PostgresRepository) DeleteByUserId(ctx context.Context, userId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE "user"

--- a/pkg/authz/user/sqlite.go
+++ b/pkg/authz/user/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newUserId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newUserId,
 		`
@@ -60,7 +60,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -86,7 +86,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetByUserId(ctx context.Context, userId string) (Model, error) {
 	var user User
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&user,
 		`
@@ -241,7 +241,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 		}
 	}
 
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&users,
 		query,
@@ -264,7 +264,7 @@ func (repo SQLiteRepository) List(ctx context.Context, listParams service.ListPa
 }
 
 func (repo SQLiteRepository) UpdateByUserId(ctx context.Context, userId string, model Model) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE user
@@ -287,7 +287,7 @@ func (repo SQLiteRepository) UpdateByUserId(ctx context.Context, userId string, 
 }
 
 func (repo SQLiteRepository) DeleteByUserId(ctx context.Context, userId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE user

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -17,12 +17,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO warrant (
@@ -61,7 +61,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 }
 
 func (repo MySQLRepository) DeleteById(ctx context.Context, id int64) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -86,7 +86,7 @@ func (repo MySQLRepository) DeleteById(ctx context.Context, id int64) error {
 }
 
 func (repo MySQLRepository) DeleteAllByObject(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -114,7 +114,7 @@ func (repo MySQLRepository) DeleteAllByObject(ctx context.Context, objectType st
 }
 
 func (repo MySQLRepository) DeleteAllBySubject(ctx context.Context, subjectType string, subjectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -143,7 +143,7 @@ func (repo MySQLRepository) DeleteAllBySubject(ctx context.Context, subjectType 
 
 func (repo MySQLRepository) Get(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -189,7 +189,7 @@ func (repo MySQLRepository) Get(ctx context.Context, objectType string, objectId
 
 func (repo MySQLRepository) GetByID(ctx context.Context, id int64) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -266,7 +266,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 	offset := (listParams.Page - 1) * listParams.Limit
 	query = fmt.Sprintf("%s LIMIT ?, ?", query)
 	replacements = append(replacements, offset, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		query,
@@ -291,7 +291,7 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 func (repo MySQLRepository) GetAllMatchingObjectRelationAndSubject(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -332,7 +332,7 @@ func (repo MySQLRepository) GetAllMatchingObjectRelationAndSubject(ctx context.C
 func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -368,7 +368,7 @@ func (repo MySQLRepository) GetAllMatchingObjectAndRelation(ctx context.Context,
 func (repo MySQLRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`

--- a/pkg/authz/warrant/postgres.go
+++ b/pkg/authz/warrant/postgres.go
@@ -18,13 +18,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newWarrantId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newWarrantId,
 		`
@@ -60,7 +60,7 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 }
 
 func (repo PostgresRepository) DeleteById(ctx context.Context, id int64) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -85,7 +85,7 @@ func (repo PostgresRepository) DeleteById(ctx context.Context, id int64) error {
 }
 
 func (repo PostgresRepository) DeleteAllByObject(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -113,7 +113,7 @@ func (repo PostgresRepository) DeleteAllByObject(ctx context.Context, objectType
 }
 
 func (repo PostgresRepository) DeleteAllBySubject(ctx context.Context, subjectType string, subjectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -142,7 +142,7 @@ func (repo PostgresRepository) DeleteAllBySubject(ctx context.Context, subjectTy
 
 func (repo PostgresRepository) Get(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -188,7 +188,7 @@ func (repo PostgresRepository) Get(ctx context.Context, objectType string, objec
 
 func (repo PostgresRepository) GetByID(ctx context.Context, id int64) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -266,7 +266,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 
 	query = fmt.Sprintf(`%s LIMIT ? OFFSET ?`, query)
 	replacements = append(replacements, listParams.Limit, offset)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		query,
@@ -291,7 +291,7 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 func (repo PostgresRepository) GetAllMatchingObjectRelationAndSubject(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -332,7 +332,7 @@ func (repo PostgresRepository) GetAllMatchingObjectRelationAndSubject(ctx contex
 func (repo PostgresRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -368,7 +368,7 @@ func (repo PostgresRepository) GetAllMatchingObjectAndRelation(ctx context.Conte
 func (repo PostgresRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -17,14 +17,14 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, error) {
 	var newWarrantId int64
 	now := time.Now().UTC()
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newWarrantId,
 		`
@@ -65,7 +65,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 }
 
 func (repo SQLiteRepository) DeleteById(ctx context.Context, id int64) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -90,7 +90,7 @@ func (repo SQLiteRepository) DeleteById(ctx context.Context, id int64) error {
 }
 
 func (repo SQLiteRepository) DeleteAllByObject(ctx context.Context, objectType string, objectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -118,7 +118,7 @@ func (repo SQLiteRepository) DeleteAllByObject(ctx context.Context, objectType s
 }
 
 func (repo SQLiteRepository) DeleteAllBySubject(ctx context.Context, subjectType string, subjectId string) error {
-	_, err := repo.DB(ctx).ExecContext(
+	_, err := repo.DB.ExecContext(
 		ctx,
 		`
 			UPDATE warrant
@@ -147,7 +147,7 @@ func (repo SQLiteRepository) DeleteAllBySubject(ctx context.Context, subjectType
 
 func (repo SQLiteRepository) Get(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -193,7 +193,7 @@ func (repo SQLiteRepository) Get(ctx context.Context, objectType string, objectI
 
 func (repo SQLiteRepository) GetByID(ctx context.Context, id int64) (Model, error) {
 	var warrant Warrant
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&warrant,
 		`
@@ -270,7 +270,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 
 	query = fmt.Sprintf("%s LIMIT ?, ?", query)
 	replacements = append(replacements, offset, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		query,
@@ -295,7 +295,7 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 func (repo SQLiteRepository) GetAllMatchingObjectRelationAndSubject(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -336,7 +336,7 @@ func (repo SQLiteRepository) GetAllMatchingObjectRelationAndSubject(ctx context.
 func (repo SQLiteRepository) GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`
@@ -372,7 +372,7 @@ func (repo SQLiteRepository) GetAllMatchingObjectAndRelation(ctx context.Context
 func (repo SQLiteRepository) GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string) ([]Model, error) {
 	models := make([]Model, 0)
 	warrants := make([]Warrant, 0)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&warrants,
 		`

--- a/pkg/authz/wookie/mysql.go
+++ b/pkg/authz/wookie/mysql.go
@@ -13,12 +13,12 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo MySQLRepository) Create(ctx context.Context, version int64) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO wookie (
@@ -40,7 +40,7 @@ func (repo MySQLRepository) Create(ctx context.Context, version int64) (int64, e
 
 func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`
@@ -59,7 +59,7 @@ func (repo MySQLRepository) GetById(ctx context.Context, id int64) (Model, error
 
 func (repo MySQLRepository) GetLatest(ctx context.Context) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`

--- a/pkg/authz/wookie/postgres.go
+++ b/pkg/authz/wookie/postgres.go
@@ -13,13 +13,13 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo PostgresRepository) Create(ctx context.Context, version int64) (int64, error) {
 	var newWookieId int64
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&newWookieId,
 		`
@@ -39,7 +39,7 @@ func (repo PostgresRepository) Create(ctx context.Context, version int64) (int64
 
 func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`
@@ -58,7 +58,7 @@ func (repo PostgresRepository) GetById(ctx context.Context, id int64) (Model, er
 
 func (repo PostgresRepository) GetLatest(ctx context.Context) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`

--- a/pkg/authz/wookie/sqlite.go
+++ b/pkg/authz/wookie/sqlite.go
@@ -13,12 +13,12 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
 func (repo SQLiteRepository) Create(ctx context.Context, version int64) (int64, error) {
-	result, err := repo.DB(ctx).ExecContext(
+	result, err := repo.DB.ExecContext(
 		ctx,
 		`
 			INSERT INTO wookie (
@@ -40,7 +40,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, version int64) (int64, 
 
 func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`
@@ -59,7 +59,7 @@ func (repo SQLiteRepository) GetById(ctx context.Context, id int64) (Model, erro
 
 func (repo SQLiteRepository) GetLatest(ctx context.Context) (Model, error) {
 	var wookie Wookie
-	err := repo.DB(ctx).GetContext(
+	err := repo.DB.GetContext(
 		ctx,
 		&wookie,
 		`

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -15,5 +15,4 @@ type Database interface {
 	Ping(ctx context.Context) error
 	ReplicaSafeRead(ctx context.Context, connCallback func(ctx context.Context) error) error
 	WithinTransaction(ctx context.Context, txCallback func(ctx context.Context) error) error
-	DbHandler(ctx context.Context) interface{}
 }

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -153,7 +153,3 @@ func (ds MySQL) Ping(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (ds MySQL) DbHandler(ctx context.Context) interface{} {
-	return &ds.SQL
-}

--- a/pkg/database/postgres.go
+++ b/pkg/database/postgres.go
@@ -162,7 +162,3 @@ func (ds Postgres) Ping(ctx context.Context) error {
 	}
 	return nil
 }
-
-func (ds Postgres) DbHandler(ctx context.Context) interface{} {
-	return &ds.SQL
-}

--- a/pkg/database/sql.go
+++ b/pkg/database/sql.go
@@ -468,23 +468,15 @@ func (ds SQL) recordQueryStat(ctx context.Context, queryable SqlQueryable, query
 }
 
 type SQLRepository struct {
-	db Database
+	DB *SQL
 }
 
-func NewSQLRepository(db Database) SQLRepository {
+func NewSQLRepository(db *SQL) SQLRepository {
 	if db == nil {
 		log.Fatal().Msg("Cannot initialize SQLRepository with a nil db parameter")
 	}
-	_, ok := db.DbHandler(context.TODO()).(*SQL)
-	if !ok {
-		log.Fatal().Msg("No/invalid SQL driver provided, cannot initialize SQLRepository")
-	}
 
 	return SQLRepository{
-		db: db,
+		DB: db,
 	}
-}
-
-func (d SQLRepository) DB(ctx context.Context) *SQL {
-	return d.db.DbHandler(ctx).(*SQL)
 }

--- a/pkg/database/sqlite-stub.go
+++ b/pkg/database/sqlite-stub.go
@@ -34,7 +34,3 @@ func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
 func (ds SQLite) Ping(ctx context.Context) error {
 	return errors.New("sqlite not supported")
 }
-
-func (ds SQLite) DbHandler(ctx context.Context) interface{} {
-	return errors.New("sqlite not supported")
-}

--- a/pkg/database/sqlite.go
+++ b/pkg/database/sqlite.go
@@ -120,7 +120,3 @@ func (ds SQLite) Migrate(ctx context.Context, toVersion uint) error {
 func (ds SQLite) Ping(ctx context.Context) error {
 	return ds.Writer.PingContext(ctx)
 }
-
-func (ds SQLite) DbHandler(ctx context.Context) interface{} {
-	return &ds.SQL
-}

--- a/pkg/event/mysql.go
+++ b/pkg/event/mysql.go
@@ -17,7 +17,7 @@ type MySQLRepository struct {
 
 func NewMySQLRepository(db *database.MySQL) MySQLRepository {
 	return MySQLRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
@@ -31,7 +31,7 @@ func (repo MySQLRepository) TrackResourceEvents(ctx context.Context, models []Re
 		resourceEvents = append(resourceEvents, *NewResourceEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO resourceEvent (
@@ -112,7 +112,7 @@ func (repo MySQLRepository) ListResourceEvents(ctx context.Context, listParams L
 
 	query = fmt.Sprintf("%s %s ORDER BY createdAt DESC, BIN_TO_UUID(id) DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&resourceEvents,
 		query,
@@ -157,7 +157,7 @@ func (repo MySQLRepository) TrackAccessEvents(ctx context.Context, models []Acce
 		accessEvents = append(accessEvents, *NewAccessEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO accessEvent (
@@ -266,7 +266,7 @@ func (repo MySQLRepository) ListAccessEvents(ctx context.Context, listParams Lis
 
 	query = fmt.Sprintf("%s %s ORDER BY createdAt DESC, BIN_TO_UUID(id) DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&accessEvents,
 		query,

--- a/pkg/event/postgres.go
+++ b/pkg/event/postgres.go
@@ -19,7 +19,7 @@ type PostgresRepository struct {
 
 func NewPostgresRepository(db *database.Postgres) PostgresRepository {
 	return PostgresRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
@@ -33,7 +33,7 @@ func (repo PostgresRepository) TrackResourceEvents(ctx context.Context, models [
 		resourceEvents = append(resourceEvents, *NewResourceEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO resource_event (
@@ -114,7 +114,7 @@ func (repo PostgresRepository) ListResourceEvents(ctx context.Context, listParam
 
 	query = fmt.Sprintf("%s %s ORDER BY created_at DESC, id DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&resourceEvents,
 		query,
@@ -159,7 +159,7 @@ func (repo PostgresRepository) TrackAccessEvents(ctx context.Context, models []A
 		accessEvents = append(accessEvents, *NewAccessEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO access_event (
@@ -268,7 +268,7 @@ func (repo PostgresRepository) ListAccessEvents(ctx context.Context, listParams 
 
 	query = fmt.Sprintf("%s %s ORDER BY created_at DESC, id DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&accessEvents,
 		query,

--- a/pkg/event/sqlite.go
+++ b/pkg/event/sqlite.go
@@ -17,7 +17,7 @@ type SQLiteRepository struct {
 
 func NewSQLiteRepository(db *database.SQLite) SQLiteRepository {
 	return SQLiteRepository{
-		database.NewSQLRepository(db),
+		database.NewSQLRepository(&db.SQL),
 	}
 }
 
@@ -31,7 +31,7 @@ func (repo SQLiteRepository) TrackResourceEvents(ctx context.Context, models []R
 		resourceEvents = append(resourceEvents, *NewResourceEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO resourceEvent (
@@ -114,7 +114,7 @@ func (repo SQLiteRepository) ListResourceEvents(ctx context.Context, listParams 
 
 	query = fmt.Sprintf("%s %s ORDER BY createdAt DESC, id DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&resourceEvents,
 		query,
@@ -159,7 +159,7 @@ func (repo SQLiteRepository) TrackAccessEvents(ctx context.Context, models []Acc
 		accessEvents = append(accessEvents, *NewAccessEventFromModel(model))
 	}
 
-	result, err := repo.DB(ctx).NamedExecContext(
+	result, err := repo.DB.NamedExecContext(
 		ctx,
 		`
 		   INSERT INTO accessEvent (
@@ -270,7 +270,7 @@ func (repo SQLiteRepository) ListAccessEvents(ctx context.Context, listParams Li
 
 	query = fmt.Sprintf("%s %s ORDER BY createdAt DESC, id DESC LIMIT ?", query, strings.Join(conditions, " AND "))
 	replacements = append(replacements, listParams.Limit)
-	err := repo.DB(ctx).SelectContext(
+	err := repo.DB.SelectContext(
 		ctx,
 		&accessEvents,
 		query,


### PR DESCRIPTION
## Describe your changes
- Since all SQL db logic happens within the SQL type, revert the SQLRepository back to the way it was before (holding a ref to *SQL that all repos can use)

## Issue number and link (if applicable)
