### PR TITLE
Add a config toggle for enabling/disabling warrant tokens (wookies)

### DIFF
--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -201,7 +201,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Could not initialize WookieRepository")
 	}
-	wookieSvc := wookie.NewService(svcEnv, wookieRepository)
+	wookieSvc := wookie.NewService(svcEnv, wookieRepository, cfg.EnableWarrantTokens)
 
 	// Init object type repo and service
 	objectTypeRepository, err := objecttype.NewRepository(svcEnv.DB())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,13 +35,14 @@ type Config interface {
 }
 
 type WarrantConfig struct {
-	Port            int               `mapstructure:"port"`
-	LogLevel        int8              `mapstructure:"logLevel"`
-	EnableAccessLog bool              `mapstructure:"enableAccessLog"`
-	AutoMigrate     bool              `mapstructure:"autoMigrate"`
-	Datastore       *DatastoreConfig  `mapstructure:"datastore"`
-	Eventstore      *EventstoreConfig `mapstructure:"eventstore"`
-	Authentication  *AuthConfig       `mapstructure:"authentication"`
+	Port                int               `mapstructure:"port"`
+	LogLevel            int8              `mapstructure:"logLevel"`
+	EnableAccessLog     bool              `mapstructure:"enableAccessLog"`
+	AutoMigrate         bool              `mapstructure:"autoMigrate"`
+	Datastore           *DatastoreConfig  `mapstructure:"datastore"`
+	Eventstore          *EventstoreConfig `mapstructure:"eventstore"`
+	Authentication      *AuthConfig       `mapstructure:"authentication"`
+	EnableWarrantTokens bool              `mapstructure:"enableWarrantTokens"`
 }
 
 func (warrantConfig WarrantConfig) GetPort() int {
@@ -138,6 +139,7 @@ func NewConfig() WarrantConfig {
 	viper.SetDefault("logLevel", zerolog.DebugLevel)
 	viper.SetDefault("enableAccessLog", true)
 	viper.SetDefault("autoMigrate", false)
+	viper.SetDefault("enableWarrantTokens", false)
 	viper.SetDefault("datastore.mysql.migrationSource", DefaultMySQLDatastoreMigrationSource)
 	viper.SetDefault("datastore.postgres.migrationSource", DefaultPostgresDatastoreMigrationSource)
 	viper.SetDefault("datastore.sqlite.migrationSource", DefaultSQLiteDatastoreMigrationSource)


### PR DESCRIPTION
## Describe your changes
- Make warrant tokens (wookies) enabled/disabled configurable. If disabled, no wookies will be generated or considered in read ops. If enabled, wookies are considered in reads and updated wookies are returned in API responses.

## Issue number and link (if applicable)
