### PR TITLE
Remove cascade deletion of warrants when an object is deleted

### DIFF
--- a/pkg/authz/feature/handlers.go
+++ b/pkg/authz/feature/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -115,11 +114,10 @@ func DeleteHandler(svc FeatureService, w http.ResponseWriter, r *http.Request) e
 		return service.NewMissingRequiredParameterError("featureId")
 	}
 
-	newWookie, err := svc.DeleteByFeatureId(r.Context(), featureId)
+	err := svc.DeleteByFeatureId(r.Context(), featureId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	return nil
 }

--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -5,7 +5,6 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -115,15 +114,14 @@ func (svc FeatureService) UpdateByFeatureId(ctx context.Context, featureId strin
 	return updatedFeatureSpec, nil
 }
 
-func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByFeatureId(txCtx, featureId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeFeature, featureId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeFeature, featureId)
 		if err != nil {
 			return err
 		}
@@ -136,8 +134,8 @@ func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId strin
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/object/handlers.go
+++ b/pkg/authz/object/handlers.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -91,11 +90,10 @@ func GetHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error
 func DeleteHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
 	objectType := mux.Vars(r)["objectType"]
 	objectId := mux.Vars(r)["objectId"]
-	newWookie, err := svc.DeleteByObjectTypeAndId(r.Context(), objectType, objectId)
+	err := svc.DeleteByObjectTypeAndId(r.Context(), objectType, objectId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	w.Header().Set("Content-type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	warrant "github.com/warrant-dev/warrant/pkg/authz/warrant"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -45,26 +44,12 @@ func (svc ObjectService) Create(ctx context.Context, objectSpec ObjectSpec) (*Ob
 	return newObject.ToObjectSpec(), nil
 }
 
-func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
-	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		err := svc.Repository.DeleteByObjectTypeAndId(txCtx, objectType, objectId)
-		if err != nil {
-			return err
-		}
-
-		newWookie, err = svc.WarrantSvc.DeleteRelatedWarrants(txCtx, objectType, objectId)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-
+func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
+	err := svc.Repository.DeleteByObjectTypeAndId(ctx, objectType, objectId)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return newWookie, nil
+	return nil
 }
 
 func (svc ObjectService) GetByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (*ObjectSpec, error) {

--- a/pkg/authz/permission/handlers.go
+++ b/pkg/authz/permission/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -115,11 +114,10 @@ func DeleteHandler(svc PermissionService, w http.ResponseWriter, r *http.Request
 		return service.NewMissingRequiredParameterError("permissionId")
 	}
 
-	newWookie, err := svc.DeleteByPermissionId(r.Context(), permissionId)
+	err := svc.DeleteByPermissionId(r.Context(), permissionId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	return nil
 }

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -5,7 +5,6 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -116,15 +115,14 @@ func (svc PermissionService) UpdateByPermissionId(ctx context.Context, permissio
 	return updatedPermissionSpec, nil
 }
 
-func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissionId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissionId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByPermissionId(txCtx, permissionId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePermission, permissionId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePermission, permissionId)
 		if err != nil {
 			return err
 		}
@@ -137,8 +135,8 @@ func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissio
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/pricingtier/handlers.go
+++ b/pkg/authz/pricingtier/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -115,11 +114,10 @@ func DeleteHandler(svc PricingTierService, w http.ResponseWriter, r *http.Reques
 		return service.NewMissingRequiredParameterError("pricingTierId")
 	}
 
-	newWookie, err := svc.DeleteByPricingTierId(r.Context(), pricingTierId)
+	err := svc.DeleteByPricingTierId(r.Context(), pricingTierId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	return nil
 }

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -5,7 +5,6 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -116,15 +115,14 @@ func (svc PricingTierService) UpdateByPricingTierId(ctx context.Context, pricing
 	return updatedPricingTierSpec, nil
 }
 
-func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricingTierId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByPricingTierId(txCtx, pricingTierId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePricingTier, pricingTierId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypePricingTier, pricingTierId)
 		if err != nil {
 			return err
 		}
@@ -137,8 +135,8 @@ func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricing
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/role/handlers.go
+++ b/pkg/authz/role/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -115,11 +114,10 @@ func DeleteHandler(svc RoleService, w http.ResponseWriter, r *http.Request) erro
 		return service.NewMissingRequiredParameterError("roleId")
 	}
 
-	newWookie, err := svc.DeleteByRoleId(r.Context(), roleId)
+	err := svc.DeleteByRoleId(r.Context(), roleId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	return nil
 }

--- a/pkg/authz/role/service.go
+++ b/pkg/authz/role/service.go
@@ -5,7 +5,6 @@ import (
 
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -116,15 +115,14 @@ func (svc RoleService) UpdateByRoleId(ctx context.Context, roleId string, roleSp
 	return updatedRoleSpec, nil
 }
 
-func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByRoleId(txCtx, roleId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeRole, roleId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeRole, roleId)
 		if err != nil {
 			return err
 		}
@@ -137,8 +135,8 @@ func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) (*wook
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/tenant/handlers.go
+++ b/pkg/authz/tenant/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -111,11 +110,10 @@ func UpdateHandler(svc TenantService, w http.ResponseWriter, r *http.Request) er
 
 func DeleteHandler(svc TenantService, w http.ResponseWriter, r *http.Request) error {
 	tenantId := mux.Vars(r)["tenantId"]
-	newWookie, err := svc.DeleteByTenantId(r.Context(), tenantId)
+	err := svc.DeleteByTenantId(r.Context(), tenantId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	w.Header().Set("Content-type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/pkg/authz/tenant/service.go
+++ b/pkg/authz/tenant/service.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -131,15 +130,14 @@ func (svc TenantService) UpdateByTenantId(ctx context.Context, tenantId string, 
 	return updatedTenantSpec, nil
 }
 
-func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByTenantId(txCtx, tenantId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeTenant, tenantId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeTenant, tenantId)
 		if err != nil {
 			return err
 		}
@@ -152,8 +150,8 @@ func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/user/handlers.go
+++ b/pkg/authz/user/handlers.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -110,11 +109,10 @@ func UpdateHandler(svc UserService, w http.ResponseWriter, r *http.Request) erro
 
 func DeleteHandler(svc UserService, w http.ResponseWriter, r *http.Request) error {
 	userId := mux.Vars(r)["userId"]
-	newWookie, err := svc.DeleteByUserId(r.Context(), userId)
+	err := svc.DeleteByUserId(r.Context(), userId)
 	if err != nil {
 		return err
 	}
-	wookie.AddAsResponseHeader(w, newWookie)
 
 	w.Header().Set("Content-type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	object "github.com/warrant-dev/warrant/pkg/authz/object"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
-	wookie "github.com/warrant-dev/warrant/pkg/authz/wookie"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
@@ -131,15 +130,14 @@ func (svc UserService) UpdateByUserId(ctx context.Context, userId string, userSp
 	return updatedUserSpec, nil
 }
 
-func (svc UserService) DeleteByUserId(ctx context.Context, userId string) (*wookie.Token, error) {
-	var newWookie *wookie.Token
+func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		err := svc.Repository.DeleteByUserId(txCtx, userId)
 		if err != nil {
 			return err
 		}
 
-		newWookie, err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeUser, userId)
+		err = svc.ObjectSvc.DeleteByObjectTypeAndId(txCtx, objecttype.ObjectTypeUser, userId)
 		if err != nil {
 			return err
 		}
@@ -153,7 +151,7 @@ func (svc UserService) DeleteByUserId(ctx context.Context, userId string) (*wook
 	})
 
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return newWookie, nil
+	return nil
 }

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -139,24 +139,3 @@ func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) (
 
 	return newWookie, nil
 }
-
-func (svc WarrantService) DeleteRelatedWarrants(ctx context.Context, objectType string, objectId string) (*wookie.Token, error) {
-	newWookie, e := svc.WookieSvc.WithWookieUpdate(ctx, func(txCtx context.Context) error {
-		err := svc.Repository.DeleteAllByObject(txCtx, objectType, objectId)
-		if err != nil {
-			return err
-		}
-
-		err = svc.Repository.DeleteAllBySubject(txCtx, objectType, objectId)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	})
-	if e != nil {
-		return nil, e
-	}
-
-	return newWookie, nil
-}

--- a/tests/authz-policy.json
+++ b/tests/authz-policy.json
@@ -229,7 +229,7 @@
                         "objectType": "user",
                         "objectId": "user-a"
                     },
-                    "policy": "clientIp matches \"192\\.168\\..*\\..*\""
+                    "policy": "clientIp matches \"192\\\\.168\\\\..*\\\\..*\""
                 }
             },
             "expectedResponse": {

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -729,7 +729,7 @@
             }
         },
         {
-            "name": "removeRoleSeniorAccountantFromUserWithContext",
+            "name": "removeRoleSeniorAccountantFromUserAInTenantA",
             "request": {
                 "method": "DELETE",
                 "url": "/v1/warrants",
@@ -742,6 +742,26 @@
                         "objectId": "user-a"
                     },
                     "policy": "tenant == \"tenant-a\""
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeRoleAdminFromUserBInTenantB",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-b"
+                    },
+                    "policy": "tenant == \"tenant-b\""
                 }
             },
             "expectedResponse": {

--- a/tests/pricing-tiers-and-features.json
+++ b/tests/pricing-tiers-and-features.json
@@ -4,69 +4,69 @@
     ],
     "tests": [
         {
-            "name": "createUser1ForTenant1",
+            "name": "createUser1",
             "request": {
                 "method": "POST",
                 "url": "/v1/users",
                 "body": {
-                    "userId": "user1-t1"
+                    "userId": "user1"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "userId": "user1-t1",
+                    "userId": "user1",
                     "email": null
                 }
             }
         },
         {
-            "name": "createUser2ForTenant2",
+            "name": "createUser2",
             "request": {
                 "method": "POST",
                 "url": "/v1/users",
                 "body": {
-                    "userId": "user2-t2"
+                    "userId": "user2"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "userId": "user2-t2",
+                    "userId": "user2",
                     "email": null
                 }
             }
         },
         {
-            "name": "createTenant1Free",
+            "name": "createTenant1",
             "request": {
                 "method": "POST",
                 "url": "/v1/tenants",
                 "body": {
-                    "tenantId": "tenant1-free"
+                    "tenantId": "tenant1"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "tenantId": "tenant1-free",
+                    "tenantId": "tenant1",
                     "name": null
                 }
             }
         },
         {
-            "name": "createTenant2Enterprise",
+            "name": "createTenant2",
             "request": {
                 "method": "POST",
                 "url": "/v1/tenants",
                 "body": {
-                    "tenantId": "tenant2-enterprise"
+                    "tenantId": "tenant2"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
-                    "tenantId": "tenant2-enterprise",
+                    "tenantId": "tenant2",
                     "name": null
                 }
             }
@@ -78,11 +78,11 @@
                 "url": "/v1/warrants",
                 "body": {
                     "objectType": "tenant",
-                    "objectId": "tenant1-free",
+                    "objectId": "tenant1",
                     "relation": "member",
                     "subject": {
                         "objectType": "user",
-                        "objectId": "user1-t1"
+                        "objectId": "user1"
                     }
                 }
             },
@@ -90,11 +90,11 @@
                 "statusCode": 200,
                 "body": {
                     "objectType": "tenant",
-                    "objectId": "tenant1-free",
+                    "objectId": "tenant1",
                     "relation": "member",
                     "subject": {
                         "objectType": "user",
-                        "objectId": "user1-t1"
+                        "objectId": "user1"
                     }
                 }
             }
@@ -106,11 +106,11 @@
                 "url": "/v1/warrants",
                 "body": {
                     "objectType": "tenant",
-                    "objectId": "tenant2-enterprise",
+                    "objectId": "tenant2",
                     "relation": "member",
                     "subject": {
                         "objectType": "user",
-                        "objectId": "user2-t2"
+                        "objectId": "user2"
                     }
                 }
             },
@@ -118,11 +118,11 @@
                 "statusCode": 200,
                 "body": {
                     "objectType": "tenant",
-                    "objectId": "tenant2-enterprise",
+                    "objectId": "tenant2",
                     "relation": "member",
                     "subject": {
                         "objectType": "user",
-                        "objectId": "user2-t2"
+                        "objectId": "user2"
                     }
                 }
             }
@@ -298,7 +298,7 @@
                     "relation": "member",
                     "subject": {
                         "objectType": "tenant",
-                        "objectId": "tenant1-free"
+                        "objectId": "tenant1"
                     }
                 }
             },
@@ -310,7 +310,7 @@
                     "relation": "member",
                     "subject": {
                         "objectType": "tenant",
-                        "objectId": "tenant1-free"
+                        "objectId": "tenant1"
                     }
                 }
             }
@@ -326,7 +326,7 @@
                     "relation": "member",
                     "subject": {
                         "objectType": "tenant",
-                        "objectId": "tenant2-enterprise"
+                        "objectId": "tenant2"
                     }
                 }
             },
@@ -338,7 +338,7 @@
                     "relation": "member",
                     "subject": {
                         "objectType": "tenant",
-                        "objectId": "tenant2-enterprise"
+                        "objectId": "tenant2"
                     }
                 }
             }
@@ -357,7 +357,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "tenant",
-                                "objectId": "tenant1-free"
+                                "objectId": "tenant1"
                             }
                         }
                     ]
@@ -385,7 +385,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "tenant",
-                                "objectId": "tenant1-free"
+                                "objectId": "tenant1"
                             }
                         }
                     ]
@@ -413,7 +413,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "user",
-                                "objectId": "user1-t1"
+                                "objectId": "user1"
                             }
                         }
                     ]
@@ -441,7 +441,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "user",
-                                "objectId": "user1-t1"
+                                "objectId": "user1"
                             }
                         }
                     ]
@@ -469,7 +469,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "tenant",
-                                "objectId": "tenant2-enterprise"
+                                "objectId": "tenant2"
                             }
                         }
                     ]
@@ -497,7 +497,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "tenant",
-                                "objectId": "tenant2-enterprise"
+                                "objectId": "tenant2"
                             }
                         }
                     ]
@@ -525,7 +525,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "user",
-                                "objectId": "user2-t2"
+                                "objectId": "user2"
                             }
                         }
                     ]
@@ -553,7 +553,7 @@
                             "relation": "member",
                             "subject": {
                                 "objectType": "user",
-                                "objectId": "user2-t2"
+                                "objectId": "user2"
                             }
                         }
                     ]
@@ -568,30 +568,76 @@
             }
         },
         {
-            "name": "deleteFreePricingTier",
+            "name": "removeEnterpriseTierFromTenant2",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/pricing-tiers/free"
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "pricing-tier",
+                    "objectId": "enterprise",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "tenant",
+                        "objectId": "tenant2"
+                    }
+                }
             },
             "expectedResponse": {
                 "statusCode": 200
             }
         },
         {
-            "name": "deleteEnterprisePricingTier",
+            "name": "removeFreeTierFromTenant1",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/pricing-tiers/enterprise"
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "pricing-tier",
+                    "objectId": "free",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "tenant",
+                        "objectId": "tenant1"
+                    }
+                }
             },
             "expectedResponse": {
                 "statusCode": 200
             }
         },
         {
-            "name": "deleteDashboardFeature",
+            "name": "removeEnterpriseTierImpliesFreeTier",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/features/dashboard"
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "pricing-tier",
+                    "objectId": "free",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "pricing-tier",
+                        "objectId": "enterprise"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeDashboardFeatureFromFreeTier",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "feature",
+                    "objectId": "dashboard",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "pricing-tier",
+                        "objectId": "free"
+                    }
+                }
             },
             "expectedResponse": {
                 "statusCode": 200
@@ -608,10 +654,68 @@
             }
         },
         {
-            "name": "deleteTenant1",
+            "name": "deleteDashboardFeature",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/tenants/tenant1-free"
+                "url": "/v1/features/dashboard"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteEnterprisePricingTier",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/pricing-tiers/enterprise"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteFreePricingTier",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/pricing-tiers/free"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeUser2FromTenant2",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "tenant",
+                    "objectId": "tenant2",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user2"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "removeUser1FromTenant1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "tenant",
+                    "objectId": "tenant1",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user1"
+                    }
+                }
             },
             "expectedResponse": {
                 "statusCode": 200
@@ -621,17 +725,27 @@
             "name": "deleteTenant2",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/tenants/tenant2-enterprise"
+                "url": "/v1/tenants/tenant2"
             },
             "expectedResponse": {
                 "statusCode": 200
             }
         },
         {
-            "name": "deleteUser1",
+            "name": "deleteTenant1",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/users/user1-t1"
+                "url": "/v1/tenants/tenant1"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteTenant2",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/tenants/tenant2"
             },
             "expectedResponse": {
                 "statusCode": 200
@@ -641,7 +755,17 @@
             "name": "deleteUser2",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/users/user2-t2"
+                "url": "/v1/users/user2"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUser1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/users/user1"
             },
             "expectedResponse": {
                 "statusCode": 200


### PR DESCRIPTION
## Describe your changes
This PR removes the cascade deletion of warrants related to an object when that object is deleted. Because some objects can be associated with a large number of warrants, this operation can be pretty expensive. Instead, it's left up to the user to delete all associated warrants before deleting the underlying object. Unreferenced warrants can also be cleaned up after the fact.

## Issue number and link (if applicable)
N/A