### PR TITLE
Track events for cascade warrant deletes on object deletion

### DIFF
--- a/pkg/authz/warrant/repository.go
+++ b/pkg/authz/warrant/repository.go
@@ -17,9 +17,10 @@ type WarrantRepository interface {
 	GetAllMatchingObjectAndRelation(ctx context.Context, objectType string, objectId string, relation string) ([]Model, error)
 	GetAllMatchingObjectAndRelationBySubjectType(ctx context.Context, objectType string, objectId string, relation string, subjectType string) ([]Model, error)
 	List(ctx context.Context, filterOptions *FilterOptions, listParams service.ListParams) ([]Model, error)
-	DeleteById(ctx context.Context, id int64) error
-	DeleteAllByObject(ctx context.Context, objectType string, objectId string) error
-	DeleteAllBySubject(ctx context.Context, subjectType string, subjectId string) error
+	Delete(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) error
+	DeleteById(ctx context.Context, ids []int64) error
+	GetAllMatchingObject(ctx context.Context, objectType string, objectId string) ([]Model, error)
+	GetAllMatchingSubject(ctx context.Context, subjectType string, subjectId string) ([]Model, error)
 }
 
 func NewRepository(db database.Database) (WarrantRepository, error) {

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -193,11 +193,11 @@ func (svc WarrantService) DeleteRelatedWarrants(ctx context.Context, objectType 
 			if err != nil {
 				return err
 			}
-		}
 
-		err = svc.EventSvc.TrackAccessEvents(ctx, accessRevokedEvents)
-		if err != nil {
-			return err
+			err = svc.EventSvc.TrackAccessEvents(ctx, accessRevokedEvents)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/database"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -64,32 +65,39 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 	return newWarrantId, nil
 }
 
-func (repo SQLiteRepository) DeleteById(ctx context.Context, id int64) error {
-	_, err := repo.DB.ExecContext(
-		ctx,
+func (repo SQLiteRepository) DeleteById(ctx context.Context, ids []int64) error {
+	query, args, err := sqlx.In(
 		`
 			UPDATE warrant
 			SET deletedAt = ?
 			WHERE
-				id = ? AND
+				id IN (?) AND
 				deletedAt IS NULL
 		`,
 		time.Now().UTC(),
-		id,
+		ids,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "error deleting warrants %v", ids)
+	}
+	_, err = repo.DB.ExecContext(
+		ctx,
+		query,
+		args...,
 	)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return service.NewRecordNotFoundError("Warrant", id)
+			return nil
 		default:
-			return errors.Wrapf(err, "error deleting warrant %d", id)
+			return errors.Wrapf(err, "error deleting warrants %v", ids)
 		}
 	}
 
 	return nil
 }
 
-func (repo SQLiteRepository) DeleteAllByObject(ctx context.Context, objectType string, objectId string) error {
+func (repo SQLiteRepository) Delete(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) error {
 	_, err := repo.DB.ExecContext(
 		ctx,
 		`
@@ -99,50 +107,106 @@ func (repo SQLiteRepository) DeleteAllByObject(ctx context.Context, objectType s
 			WHERE
 				objectType = ? AND
 				objectId = ? AND
+				relation = ? AND
+				subjectType = ? AND
+				subjectId = ? AND
+				subjectRelation = ? AND
+				policyHash = ? AND
 				deletedAt IS NULL
 		`,
 		time.Now().UTC(),
 		objectType,
 		objectId,
+		relation,
+		subjectType,
+		subjectId,
+		subjectRelation,
+		policyHash,
 	)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil
+			wntErrorId := fmt.Sprintf("%s:%s#%s@%s:%s", objectType, objectId, relation, subjectType, subjectId)
+			if subjectRelation != "" {
+				wntErrorId = fmt.Sprintf("%s#%s", wntErrorId, subjectRelation)
+			}
+			if policyHash != "" {
+				wntErrorId = fmt.Sprintf("%s[%s]", wntErrorId, policyHash)
+			}
+
+			return service.NewRecordNotFoundError("Warrant", wntErrorId)
 		default:
-			return errors.Wrapf(err, "error deleting warrants with object %s:%s", objectType, objectId)
+			return errors.Wrap(err, "error deleting warrant")
 		}
 	}
 
 	return nil
 }
 
-func (repo SQLiteRepository) DeleteAllBySubject(ctx context.Context, subjectType string, subjectId string) error {
-	_, err := repo.DB.ExecContext(
+func (repo SQLiteRepository) GetAllMatchingObject(ctx context.Context, objectType string, objectId string) ([]Model, error) {
+	models := make([]Model, 0)
+	warrants := make([]Warrant, 0)
+	err := repo.DB.SelectContext(
 		ctx,
+		&warrants,
 		`
-			UPDATE warrant
-			SET
-				deletedAt = ?
+			SELECT id, objectType, objectId, relation, subjectType, subjectId, subjectRelation, policy, createdAt, updatedAt, deletedAt
+			FROM warrant
+			WHERE
+				objectType = ? AND
+				objectId = ? AND
+				deletedAt IS NULL
+		`,
+		objectType,
+		objectId,
+	)
+	if err != nil {
+		switch err {
+		case sql.ErrNoRows:
+			return models, nil
+		default:
+			return models, errors.Wrapf(err, "error deleting warrants with object %s:%s", objectType, objectId)
+		}
+	}
+
+	for i := range warrants {
+		models = append(models, &warrants[i])
+	}
+
+	return models, nil
+}
+
+func (repo SQLiteRepository) GetAllMatchingSubject(ctx context.Context, subjectType string, subjectId string) ([]Model, error) {
+	models := make([]Model, 0)
+	warrants := make([]Warrant, 0)
+	err := repo.DB.SelectContext(
+		ctx,
+		&warrants,
+		`
+			SELECT id, objectType, objectId, relation, subjectType, subjectId, subjectRelation, policy, createdAt, updatedAt, deletedAt
+			FROM warrant
 			WHERE
 				subjectType = ? AND
 				subjectId = ? AND
 				deletedAt IS NULL
 		`,
-		time.Now().UTC(),
 		subjectType,
 		subjectId,
 	)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:
-			return nil
+			return models, nil
 		default:
-			return errors.Wrapf(err, "error deleting warrants with subject %s:%s", subjectType, subjectId)
+			return models, errors.Wrapf(err, "error deleting warrants with subject %s:%s", subjectType, subjectId)
 		}
 	}
 
-	return nil
+	for i := range warrants {
+		models = append(models, &warrants[i])
+	}
+
+	return models, nil
 }
 
 func (repo SQLiteRepository) Get(ctx context.Context, objectType string, objectId string, relation string, subjectType string, subjectId string, subjectRelation string, policyHash string) (Model, error) {

--- a/tests/authz-policy.json
+++ b/tests/authz-policy.json
@@ -229,7 +229,7 @@
                         "objectType": "user",
                         "objectId": "user-a"
                     },
-                    "policy": "clientIp matches \"192\\.168\\..*\\..*\""
+                    "policy": "clientIp matches \"192\\\\.168\\\\..*\\\\..*\""
                 }
             },
             "expectedResponse": {


### PR DESCRIPTION
## Describe your changes
This PR updates the warrant service's `DeleteRelatedWarrants` method to track `access_revoked` events when cascade deleting warrants related to a deleted object.

## Issue number and link (if applicable)
N/A