### PR TITLE
Add DSN field to mysql config

### DIFF
--- a/migrations/datastore/mysql/README.md
+++ b/migrations/datastore/mysql/README.md
@@ -45,8 +45,9 @@ You may also customize your database or eventstore connection by providing a [DS
 ```yaml
 datastore:
   mysql:
-    dsn: root:@tcp(127.0.0.1:3306)/warrant
+    dsn: root:@tcp(127.0.0.1:3306)/warrant?parseTime=true
 ```
+Note: `parseTime=true` must be included when providing a DSN to parse `DATE` and `DATETIME` values to `time.Time`.
 
 ## Running db migrations
 

--- a/migrations/datastore/mysql/README.md
+++ b/migrations/datastore/mysql/README.md
@@ -40,6 +40,14 @@ Note: You must use 2 different databases for `datastore` and `eventstore`. You c
 
 The `synchronizeEvents` attribute in the eventstore section is false by default. Setting it to true means that all events will be tracked in order within the same transaction (helpful for testing locally).
 
+You may also customize your database or eventstore connection by providing a [DSN (Data Source Name)](https://github.com/go-sql-driver/mysql#dsn-data-source-name). If provided, this string is used to open the given database rather using the individual variables, i.e. `user`, `password`, `hostname`.
+
+```yaml
+datastore:
+  mysql:
+    dsn: root:@tcp(127.0.0.1:3306)/warrant
+```
+
 ## Running db migrations
 
 Warrant uses [golang-migrate](https://github.com/golang-migrate/migrate) to manage sql db migrations. If the `autoMigrate` config flag is set to true, the server will automatically run migrations on start. If you prefer managing migrations and upgrades manually, please set the `autoMigrate` flag to false.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -91,6 +91,7 @@ type MySQLConfig struct {
 	ReaderMaxIdleConnections int    `mapstructure:"readerMaxIdleConnections"`
 	ReaderMaxOpenConnections int    `mapstructure:"readerMaxOpenConnections"`
 	DSN                      string `mapstructure:"dsn"`
+	ReaderDSN                string `mapstructure:"readerDsn"`
 }
 
 type PostgresConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,6 +90,7 @@ type MySQLConfig struct {
 	ReaderHostname           string `mapstructure:"readerHostname"`
 	ReaderMaxIdleConnections int    `mapstructure:"readerMaxIdleConnections"`
 	ReaderMaxOpenConnections int    `mapstructure:"readerMaxOpenConnections"`
+	DSN                      string `mapstructure:"dsn"`
 }
 
 type PostgresConfig struct {

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -68,8 +68,8 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	// connect to reader if provided
 	if ds.Config.ReaderHostname != "" {
 		var reader *sqlx.DB
-		if ds.Config.DSN != "" {
-			reader, err = sqlx.Open("mysql", ds.Config.DSN)
+		if ds.Config.ReaderDSN != "" {
+			reader, err = sqlx.Open("mysql", ds.Config.ReaderDSN)
 		} else {
 			reader, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.ReaderHostname, ds.Config.Database))
 		}

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -36,7 +36,12 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	var db *sqlx.DB
 	var err error
 
-	db, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.Hostname, ds.Config.Database))
+	if ds.Config.DSN != "" {
+		log.Debug().Msgf("DSN: %+v", ds.Config.DSN)
+		db, err = sqlx.Open("mysql", ds.Config.DSN)
+	} else {
+		db, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.Hostname, ds.Config.Database))
+	}
 	if err != nil {
 		return errors.Wrap(err, "Unable to establish connection to mysql. Shutting down server.")
 	}
@@ -62,7 +67,12 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 
 	// connect to reader if provided
 	if ds.Config.ReaderHostname != "" {
-		reader, err := sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.ReaderHostname, ds.Config.Database))
+		var reader *sqlx.DB
+		if ds.Config.DSN != "" {
+			reader, err = sqlx.Open("mysql", ds.Config.DSN)
+		} else {
+			reader, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.ReaderHostname, ds.Config.Database))
+		}
 		if err != nil {
 			return errors.Wrap(err, "Unable to establish connection to mysql reader. Shutting down server.")
 		}

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -36,21 +36,6 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	var db *sqlx.DB
 	var err error
 
-	// open new database connection without specifying the database name
-	db, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.Hostname))
-	if err != nil {
-		return errors.Wrap(err, "Unable to establish connection to mysql. Shutting down server.")
-	}
-
-	// create database if it does not already exist
-	_, err = db.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", ds.Config.Database))
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("Unable to create database %s in mysql", ds.Config.Database))
-	}
-
-	db.Close()
-
-	// open new database connection, this time specifying the database name
 	db, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.Hostname, ds.Config.Database))
 	if err != nil {
 		return errors.Wrap(err, "Unable to establish connection to mysql. Shutting down server.")


### PR DESCRIPTION
## Describe your changes
This PR adds support for DSN (Data Source Name) to the MySQL configuration, which allows users to provide a string describing a connection to a datasource. This also allows users to specify any [available parameters](https://github.com/go-sql-driver/mysql#dsn-data-source-name) when providing a DSN, i.e. `root:@tcp(127.0.0.1:3306)/warrant?allowAllFiles=true&collation=latin1_swedish_ci`.
