### PR TITLE
Correctly handle DSN config

### DIFF
--- a/cmd/warrant/main.go
+++ b/cmd/warrant/main.go
@@ -51,7 +51,7 @@ func (env *ServiceEnv) InitDB(cfg config.Config) error {
 	ctx, cancelFunc := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelFunc()
 
-	if cfg.GetDatastore().MySQL.Hostname != "" {
+	if cfg.GetDatastore().MySQL.Hostname != "" || cfg.GetDatastore().MySQL.DSN != "" {
 		db := database.NewMySQL(*cfg.GetDatastore().MySQL)
 		err := db.Connect(ctx)
 		if err != nil {

--- a/pkg/database/mysql.go
+++ b/pkg/database/mysql.go
@@ -37,7 +37,6 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	var err error
 
 	if ds.Config.DSN != "" {
-		log.Debug().Msgf("DSN: %+v", ds.Config.DSN)
 		db, err = sqlx.Open("mysql", ds.Config.DSN)
 	} else {
 		db, err = sqlx.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s?parseTime=true", ds.Config.Username, ds.Config.Password, ds.Config.Hostname, ds.Config.Database))
@@ -66,7 +65,7 @@ func (ds *MySQL) Connect(ctx context.Context) error {
 	log.Info().Msgf("Connected to mysql database %s", ds.Config.Database)
 
 	// connect to reader if provided
-	if ds.Config.ReaderHostname != "" {
+	if ds.Config.ReaderHostname != "" || ds.Config.ReaderDSN != "" {
 		var reader *sqlx.DB
 		if ds.Config.ReaderDSN != "" {
 			reader, err = sqlx.Open("mysql", ds.Config.ReaderDSN)


### PR DESCRIPTION
## Describe your changes
This PR fixes the configuration setup to correctly handle cases when either a `DSN` or `ReaderDSN` is provided. When initializing the DB, an additional check is added to see if a `DSN` is provided in order to start initializing the DB connection. For initializing the reader DB, the check is also updated to see if a `ReaderDSN` has been provided to determine whether to connect to a reader instance.
