### PR TITLE
Set golangci-lint job fetch depth to 2 commits

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,6 +19,8 @@ jobs:
           cache: false
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:


### PR DESCRIPTION
## Describe your changes
- Set fetch-depth to 2. This should prevent all previous lint errors from showing up as errors in ci.

## Issue number and link (if applicable)
