### PR TITLE
Return invalid parameter error with useful error message when client attempts to create a warrant with an invalid policy

### DIFF
--- a/pkg/authz/warrant/warrant.go
+++ b/pkg/authz/warrant/warrant.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/warrant-dev/warrant/pkg/service"
 )
 
 type WarrantSpec struct {
@@ -60,7 +61,7 @@ func (spec *WarrantSpec) ToWarrant() (*Warrant, error) {
 	if spec.Policy != "" {
 		err := spec.Policy.Validate()
 		if err != nil {
-			return nil, err
+			return nil, service.NewInvalidParameterError("policy", err.Error())
 		}
 
 		warrant.Policy = spec.Policy

--- a/tests/authz-policy.json
+++ b/tests/authz-policy.json
@@ -65,6 +65,31 @@
             }
         },
         {
+            "name": "failToCreateWarrantWithInvalidPolicy",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "policy": "element = \"115\""
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 400,
+                "body": {
+                    "code": "invalid_parameter",
+                    "message": "error validating policy 'element = \"115\"': unexpected token Operator(\"=\") (1:9)\n | element = \"115\"\n | ........^",
+                    "parameter": "policy"
+                }
+            }
+        },
+        {
             "name": "failToCreateWarrantWithPolicyAndContext",
             "request": {
                 "method": "POST",


### PR DESCRIPTION
## Describe your changes
This PR updates warrant creation to return a more useful error response when the client attempt to create a warrant with an invalid policy (syntax error or otherwise).

## Issue number and link (if applicable)
N/A