### PR TITLE
Check warrant filters for nil subject

### DIFF
--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -317,19 +317,24 @@ func (repo MySQLRepository) List(ctx context.Context, filterOptions *FilterOptio
 		replacements = append(replacements, filterOptions.Relation)
 	}
 
-	if filterOptions.Subject.ObjectType != "" {
-		query = fmt.Sprintf("%s AND subjectType = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectType)
-	}
+	if filterOptions.Subject != nil {
+		if filterOptions.Subject.ObjectType != "" {
+			query = fmt.Sprintf("%s AND subjectType = ?", query)
 
-	if filterOptions.Subject.ObjectId != "" {
-		query = fmt.Sprintf("%s AND subjectId = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectId)
-	}
+			replacements = append(replacements, filterOptions.Subject.ObjectType)
+		}
 
-	if filterOptions.Subject.Relation != "" {
-		query = fmt.Sprintf("%s AND subjectRelation = ?", query)
-		replacements = append(replacements, filterOptions.Subject.Relation)
+		if filterOptions.Subject.ObjectId != "" {
+			query = fmt.Sprintf("%s AND subjectId = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.ObjectId)
+		}
+
+		if filterOptions.Subject.Relation != "" {
+			query = fmt.Sprintf("%s AND subjectRelation = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.Relation)
+		}
 	}
 
 	if filterOptions.Policy != "" {

--- a/pkg/authz/warrant/postgres.go
+++ b/pkg/authz/warrant/postgres.go
@@ -317,19 +317,24 @@ func (repo PostgresRepository) List(ctx context.Context, filterOptions *FilterOp
 		replacements = append(replacements, filterOptions.Relation)
 	}
 
-	if filterOptions.Subject.ObjectType != "" {
-		query = fmt.Sprintf("%s AND subject_type = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectType)
-	}
+	if filterOptions.Subject != nil {
+		if filterOptions.Subject.ObjectType != "" {
+			query = fmt.Sprintf("%s AND subject_type = ?", query)
 
-	if filterOptions.Subject.ObjectId != "" {
-		query = fmt.Sprintf("%s AND subject_id = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectId)
-	}
+			replacements = append(replacements, filterOptions.Subject.ObjectType)
+		}
 
-	if filterOptions.Subject.Relation != "" {
-		query = fmt.Sprintf("%s AND subject_relation = ?", query)
-		replacements = append(replacements, filterOptions.Subject.Relation)
+		if filterOptions.Subject.ObjectId != "" {
+			query = fmt.Sprintf("%s AND subject_id = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.ObjectId)
+		}
+
+		if filterOptions.Subject.Relation != "" {
+			query = fmt.Sprintf("%s AND subject_relation = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.Relation)
+		}
 	}
 
 	if filterOptions.Policy != "" {

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -322,19 +322,24 @@ func (repo SQLiteRepository) List(ctx context.Context, filterOptions *FilterOpti
 		replacements = append(replacements, filterOptions.Relation)
 	}
 
-	if filterOptions.Subject.ObjectType != "" {
-		query = fmt.Sprintf("%s AND subjectType = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectType)
-	}
+	if filterOptions.Subject != nil {
+		if filterOptions.Subject.ObjectType != "" {
+			query = fmt.Sprintf("%s AND subjectType = ?", query)
 
-	if filterOptions.Subject.ObjectId != "" {
-		query = fmt.Sprintf("%s AND subjectId = ?", query)
-		replacements = append(replacements, filterOptions.Subject.ObjectId)
-	}
+			replacements = append(replacements, filterOptions.Subject.ObjectType)
+		}
 
-	if filterOptions.Subject.Relation != "" {
-		query = fmt.Sprintf("%s AND subjectRelation = ?", query)
-		replacements = append(replacements, filterOptions.Subject.Relation)
+		if filterOptions.Subject.ObjectId != "" {
+			query = fmt.Sprintf("%s AND subjectId = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.ObjectId)
+		}
+
+		if filterOptions.Subject.Relation != "" {
+			query = fmt.Sprintf("%s AND subjectRelation = ?", query)
+
+			replacements = append(replacements, filterOptions.Subject.Relation)
+		}
 	}
 
 	if filterOptions.Policy != "" {


### PR DESCRIPTION
## Describe your changes
This PR updates the list warrants database queries to check for a nil subject in the filter options to avoid a nil reference error when filters are passed without a subject.
