### PR TITLE
Make the `objectId` field optional on object, and generate an `objectId` for objects created without one

### DIFF
--- a/pkg/authz/feature/service.go
+++ b/pkg/authz/feature/service.go
@@ -44,7 +44,7 @@ func NewService(env service.Env, repository FeatureRepository, eventSvc event.Se
 func (svc FeatureService) Create(ctx context.Context, featureSpec FeatureSpec) (*FeatureSpec, error) {
 	var newFeature Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *featureSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *featureSpec.ToCreateObjectSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/feature/spec.go
+++ b/pkg/authz/feature/spec.go
@@ -37,8 +37,8 @@ func (spec FeatureSpec) ToFeature(objectId int64) *Feature {
 	}
 }
 
-func (spec FeatureSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec FeatureSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypeFeature,
 		ObjectId:   spec.FeatureId,
 	}

--- a/pkg/authz/object/handlers.go
+++ b/pkg/authz/object/handlers.go
@@ -56,13 +56,13 @@ func (svc ObjectService) Routes() ([]service.Route, error) {
 }
 
 func CreateHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
-	var newObject ObjectSpec
-	err := service.ParseJSONBody(r.Body, &newObject)
+	var objectSpec CreateObjectSpec
+	err := service.ParseJSONBody(r.Body, &objectSpec)
 	if err != nil {
 		return err
 	}
 
-	createdObject, err := svc.Create(r.Context(), newObject)
+	createdObject, err := svc.Create(r.Context(), objectSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -43,7 +43,7 @@ func NewService(env service.Env, repository ObjectRepository, eventSvc event.Ser
 
 func (svc ObjectService) Create(ctx context.Context, objectSpec CreateObjectSpec) (*ObjectSpec, error) {
 	if objectSpec.ObjectId == "" {
-		// generate an id for the tenant if one isn't supplied
+		// generate an id for the object if one isn't supplied
 		generatedUUID, err := uuid.NewRandom()
 		if err != nil {
 			return nil, errors.New("unable to generate random UUID for object")

--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	warrant "github.com/warrant-dev/warrant/pkg/authz/warrant"
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -39,7 +41,16 @@ func NewService(env service.Env, repository ObjectRepository, eventSvc event.Ser
 	}
 }
 
-func (svc ObjectService) Create(ctx context.Context, objectSpec ObjectSpec) (*ObjectSpec, error) {
+func (svc ObjectService) Create(ctx context.Context, objectSpec CreateObjectSpec) (*ObjectSpec, error) {
+	if objectSpec.ObjectId == "" {
+		// generate an id for the tenant if one isn't supplied
+		generatedUUID, err := uuid.NewRandom()
+		if err != nil {
+			return nil, errors.New("unable to generate random UUID for object")
+		}
+		objectSpec.ObjectId = generatedUUID.String()
+	}
+
 	var newObject Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		_, err := svc.Repository.GetByObjectTypeAndId(txCtx, objectSpec.ObjectType, objectSpec.ObjectId)

--- a/pkg/authz/object/spec.go
+++ b/pkg/authz/object/spec.go
@@ -25,7 +25,7 @@ type ObjectSpec struct {
 	// However, we don't return it to the client.
 	ID         int64     `json:"-"`
 	ObjectType string    `json:"objectType" validate:"required,valid_object_type"`
-	ObjectId   string    `json:"objectId" validate:"required,valid_object_id"`
+	ObjectId   string    `json:"objectId"   validate:"required,valid_object_id"`
 	CreatedAt  time.Time `json:"createdAt"`
 }
 
@@ -39,7 +39,7 @@ func (spec ObjectSpec) ToObject() *Object {
 
 type CreateObjectSpec struct {
 	ObjectType string `json:"objectType" validate:"required"`
-	ObjectId   string `json:"objectId" validate:"omitempty,valid_object_id"`
+	ObjectId   string `json:"objectId"   validate:"omitempty,valid_object_id"`
 }
 
 func (spec CreateObjectSpec) ToObject() *Object {

--- a/pkg/authz/object/spec.go
+++ b/pkg/authz/object/spec.go
@@ -39,5 +39,12 @@ func (spec ObjectSpec) ToObject() *Object {
 
 type CreateObjectSpec struct {
 	ObjectType string `json:"objectType" validate:"required"`
-	ObjectId   string `json:"objectId" validate:"required"`
+	ObjectId   string `json:"objectId" validate:"omitempty,valid_object_id"`
+}
+
+func (spec CreateObjectSpec) ToObject() *Object {
+	return &Object{
+		ObjectType: spec.ObjectType,
+		ObjectId:   spec.ObjectId,
+	}
 }

--- a/pkg/authz/permission/service.go
+++ b/pkg/authz/permission/service.go
@@ -44,7 +44,7 @@ func NewService(env service.Env, repository PermissionRepository, eventSvc event
 func (svc PermissionService) Create(ctx context.Context, permissionSpec PermissionSpec) (*PermissionSpec, error) {
 	var newPermission Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *permissionSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *permissionSpec.ToCreateObjectSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/permission/spec.go
+++ b/pkg/authz/permission/spec.go
@@ -37,8 +37,8 @@ func (spec PermissionSpec) ToPermission(objectId int64) *Permission {
 	}
 }
 
-func (spec PermissionSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec PermissionSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypePermission,
 		ObjectId:   spec.PermissionId,
 	}

--- a/pkg/authz/pricingtier/service.go
+++ b/pkg/authz/pricingtier/service.go
@@ -44,7 +44,7 @@ func NewService(env service.Env, repository PricingTierRepository, eventSvc even
 func (svc PricingTierService) Create(ctx context.Context, pricingTierSpec PricingTierSpec) (*PricingTierSpec, error) {
 	var newPricingTier Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *pricingTierSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *pricingTierSpec.ToCreateObjectSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/pricingtier/spec.go
+++ b/pkg/authz/pricingtier/spec.go
@@ -37,8 +37,8 @@ func (spec PricingTierSpec) ToPricingTier(objectId int64) Model {
 	}
 }
 
-func (spec PricingTierSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec PricingTierSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypePricingTier,
 		ObjectId:   spec.PricingTierId,
 	}

--- a/pkg/authz/role/service.go
+++ b/pkg/authz/role/service.go
@@ -49,7 +49,7 @@ func (svc RoleService) Create(ctx context.Context, roleSpec RoleSpec) (*RoleSpec
 			return service.NewDuplicateRecordError("Role", roleSpec.RoleId, "A role with the given roleId already exists")
 		}
 
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *roleSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *roleSpec.ToCreateObjectSpec())
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/role/spec.go
+++ b/pkg/authz/role/spec.go
@@ -37,8 +37,8 @@ func (spec RoleSpec) ToRole(objectId int64) *Role {
 	}
 }
 
-func (spec RoleSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec RoleSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypeRole,
 		ObjectId:   spec.RoleId,
 	}

--- a/pkg/authz/tenant/service.go
+++ b/pkg/authz/tenant/service.go
@@ -55,7 +55,7 @@ func (svc TenantService) Create(ctx context.Context, tenantSpec TenantSpec) (*Te
 
 	var newTenant Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *tenantSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *tenantSpec.ToCreateObjectSpec())
 		if err != nil {
 			switch err.(type) {
 			case *service.DuplicateRecordError:

--- a/pkg/authz/tenant/spec.go
+++ b/pkg/authz/tenant/spec.go
@@ -35,8 +35,8 @@ func (spec TenantSpec) ToTenant(objectId int64) *Tenant {
 	}
 }
 
-func (spec TenantSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec TenantSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypeTenant,
 		ObjectId:   spec.TenantId,
 	}

--- a/pkg/authz/user/service.go
+++ b/pkg/authz/user/service.go
@@ -55,7 +55,7 @@ func (svc UserService) Create(ctx context.Context, userSpec UserSpec) (*UserSpec
 
 	var newUser Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		createdObject, err := svc.ObjectSvc.Create(txCtx, *userSpec.ToObjectSpec())
+		createdObject, err := svc.ObjectSvc.Create(txCtx, *userSpec.ToCreateObjectSpec())
 		if err != nil {
 			switch err.(type) {
 			case *service.DuplicateRecordError:

--- a/pkg/authz/user/spec.go
+++ b/pkg/authz/user/spec.go
@@ -35,8 +35,8 @@ func (spec UserSpec) ToUser(objectId int64) *User {
 	}
 }
 
-func (spec UserSpec) ToObjectSpec() *object.ObjectSpec {
-	return &object.ObjectSpec{
+func (spec UserSpec) ToCreateObjectSpec() *object.CreateObjectSpec {
+	return &object.CreateObjectSpec{
 		ObjectType: objecttype.ObjectTypeUser,
 		ObjectId:   spec.UserId,
 	}

--- a/tests/objects-crud.json
+++ b/tests/objects-crud.json
@@ -10,14 +10,14 @@
                 "url": "/v1/objects",
                 "body": {
                     "objectType": "test",
-                    "objectId": "object-1"
+                    "objectId": "first-object"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "objectType": "test",
-                    "objectId": "object-1"
+                    "objectId": "first-object"
                 }
             }
         },
@@ -28,14 +28,31 @@
                 "url": "/v1/objects",
                 "body": {
                     "objectType": "test",
-                    "objectId": "object-2"
+                    "objectId": "second-object"
                 }
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "objectType": "test",
-                    "objectId": "object-2"
+                    "objectId": "second-object"
+                }
+            }
+        },
+        {
+            "name": "createObjectWithGeneratedId",
+            "request": {
+                "method": "POST",
+                "url": "/v1/objects",
+                "body": {
+                    "objectType": "test"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "test",
+                    "objectId": "{{ createObjectWithGeneratedId.objectId }}"
                 }
             }
         },
@@ -43,13 +60,13 @@
             "name": "getObjectById",
             "request": {
                 "method": "GET",
-                "url": "/v1/objects/test/object-1"
+                "url": "/v1/objects/test/first-object"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": {
                     "objectType": "test",
-                    "objectId": "object-1"
+                    "objectId": "first-object"
                 }
             }
         },
@@ -64,11 +81,15 @@
                 "body": [
                     {
                         "objectType": "test",
-                        "objectId": "object-2"
+                        "objectId": "{{ createObjectWithGeneratedId.objectId }}"
                     },
                     {
                         "objectType": "test",
-                        "objectId": "object-1"
+                        "objectId": "second-object"
+                    },
+                    {
+                        "objectType": "test",
+                        "objectId": "first-object"
                     }
                 ]
             }
@@ -77,14 +98,14 @@
             "name": "filterObjects",
             "request": {
                 "method": "GET",
-                "url": "/v1/objects?q=1"
+                "url": "/v1/objects?q=first-object"
             },
             "expectedResponse": {
                 "statusCode": 200,
                 "body": [
                     {
                         "objectType": "test",
-                        "objectId": "object-1"
+                        "objectId": "first-object"
                     }
                 ]
             }
@@ -93,7 +114,7 @@
             "name": "deleteObject1",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/objects/test/object-1"
+                "url": "/v1/objects/test/first-object"
             },
             "expectedResponse": {
                 "statusCode": 200
@@ -103,7 +124,17 @@
             "name": "deleteObject2",
             "request": {
                 "method": "DELETE",
-                "url": "/v1/objects/test/object-2"
+                "url": "/v1/objects/test/second-object"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectWithGeneratedId",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/objects/test/{{ createObjectWithGeneratedId.objectId }}"
             },
             "expectedResponse": {
                 "statusCode": 200


### PR DESCRIPTION
## Describe your changes
With this change, it is no longer required to pass an `objectId` when creating an object. If one is passed, it will be used as the `objectId` for the created object (no change here), but if an `objectId` is not passed, the service will generate a v4 uuid to use as the `objectId` for the newly created object.

## Issue number and link (if applicable)
N/A