### PR TITLE
Return `RecordNotFoundError` from object type map

### DIFF
--- a/pkg/authz/objecttype/service.go
+++ b/pkg/authz/objecttype/service.go
@@ -16,7 +16,6 @@ package authz
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/warrant-dev/warrant/pkg/event"
 	"github.com/warrant-dev/warrant/pkg/service"
@@ -33,7 +32,7 @@ func (m ObjectTypeMap) GetByTypeId(typeId string) (*ObjectTypeSpec, error) {
 		return &val, nil
 	}
 
-	return nil, fmt.Errorf("no object type with typeId %s exists", typeId)
+	return nil, service.NewRecordNotFoundError("ObjectType", typeId)
 }
 
 type ObjectTypeService struct {

--- a/tests/authz.json
+++ b/tests/authz.json
@@ -367,6 +367,36 @@
             }
         },
         {
+            "name": "checkNonexistentObjectType",
+            "request": {
+                "method": "POST",
+                "url": "/v2/authorize",
+                "body": {
+                    "op": "anyOf",
+                    "warrants": [
+                        {
+                            "objectType": "nonexistent-object-type",
+                            "objectId": "123456",
+                            "relation": "editor",
+                            "subject": {
+                                "objectType": "user",
+                                "objectId": "user-a"
+                            }
+                        }
+                    ]
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 404,
+                "body": {
+                    "code": "not_found",
+                    "message": "ObjectType nonexistent-object-type not found",
+                    "type": "ObjectType",
+                    "key": "nonexistent-object-type"
+                }
+            }
+        },
+        {
             "name": "checkUserBEditorOfReportAInTenantB",
             "request": {
                 "method": "POST",


### PR DESCRIPTION
## Describe your changes
This PR updates the object type map lookup to return a record not found error if the requested object type is not found in the map.

## Issue number and link (if applicable)
N/A