### PR TITLE
Update the object service `Create` method to update existing objects

### DIFF
--- a/pkg/authz/object/service.go
+++ b/pkg/authz/object/service.go
@@ -16,7 +16,6 @@ package authz
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
@@ -50,11 +49,6 @@ func (svc ObjectService) Create(ctx context.Context, objectSpec CreateObjectSpec
 
 	var createdObject Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
-		_, err := svc.Repository.GetByObjectTypeAndId(txCtx, objectSpec.ObjectType, objectSpec.ObjectId)
-		if err == nil {
-			return service.NewDuplicateRecordError("Object", fmt.Sprintf("%s:%s", objectSpec.ObjectType, objectSpec.ObjectId), "An object with the given objectType and objectId already exists")
-		}
-
 		newObject, err := objectSpec.ToObject()
 		if err != nil {
 			return err

--- a/tests/tenants-crud.json
+++ b/tests/tenants-crud.json
@@ -197,25 +197,6 @@
             }
         },
         {
-            "name": "failToCreateATenantThatAlreadyExists",
-            "request": {
-                "method": "POST",
-                "url": "/v1/tenants",
-                "body": {
-                    "tenantId": "provided-tenant-id"
-                }
-            },
-            "expectedResponse": {
-                "statusCode": 400,
-                "body": {
-                    "type": "Object",
-                    "key": "tenant:provided-tenant-id",
-                    "code": "duplicate_record",
-                    "message": "Duplicate Object tenant:provided-tenant-id, An object with the given objectType and objectId already exists"
-                }
-            }
-        },
-        {
             "name": "failToCreateATenantWithInvalidTenantId",
             "request": {
                 "method": "POST",

--- a/tests/users-crud.json
+++ b/tests/users-crud.json
@@ -204,25 +204,6 @@
             }
         },
         {
-            "name": "failToCreateAUserThatAlreadyExists",
-            "request": {
-                "method": "POST",
-                "url": "/v1/users",
-                "body": {
-                    "userId": "5555555555555"
-                }
-            },
-            "expectedResponse": {
-                "statusCode": 400,
-                "body": {
-                    "type": "Object",
-                    "key": "user:5555555555555",
-                    "code": "duplicate_record",
-                    "message": "Duplicate Object user:5555555555555, An object with the given objectType and objectId already exists"
-                }
-            }
-        },
-        {
             "name": "failToCreateAUserWithInvalidUserId",
             "request": {
                 "method": "POST",

--- a/tests/warrants-crud.json
+++ b/tests/warrants-crud.json
@@ -4,6 +4,24 @@
     ],
     "tests": [
         {
+            "name": "createUserA",
+            "request": {
+                "method": "POST",
+                "url": "/v1/users",
+                "body": {
+                    "userId": "user-a",
+                    "email": "user-a@warrant.dev"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "userId": "user-a",
+                    "email": "user-a@warrant.dev"
+                }
+            }
+        },
+        {
             "name": "assignPermissionViewBalanceSheetToRoleSeniorAccountant",
             "request": {
                 "method": "POST",
@@ -138,7 +156,7 @@
             }
         },
         {
-            "name": "confirmUserACreated",
+            "name": "confirmUserAUnchanged",
             "request": {
                 "method": "GET",
                 "url": "/v1/users/user-a"
@@ -147,7 +165,7 @@
                 "statusCode": 200,
                 "body": {
                     "userId": "user-a",
-                    "email": null
+                    "email": "user-a@warrant.dev"
                 }
             }
         },

--- a/tests/zz-events.json
+++ b/tests/zz-events.json
@@ -18,7 +18,10 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "deleted",
@@ -56,8 +59,8 @@
                         {
                             "type": "created",
                             "source": "api",
-                            "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceType": "permission",
+                            "resourceId": "balance-sheet:edit"
                         }
                     ],
                     "lastId": "{{ listNextTwoResourceEvents.lastId }}"
@@ -91,7 +94,10 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "deleted",
@@ -136,13 +142,19 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "created",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "deleted",
@@ -181,13 +193,19 @@
                             "type": "deleted",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "created",
                             "source": "api",
                             "resourceType": "user",
-                            "resourceId": "user-a"
+                            "resourceId": "user-a",
+                            "meta": {
+                                "email": "user-a@warrant.dev"
+                            }
                         },
                         {
                             "type": "deleted",


### PR DESCRIPTION
## Describe your changes
This PR updates the object service's `Create` method to update the existing object (instead of returning a `DuplicateRecordError`) in the scenario that an already existing object is passed.

## Issue number and link (if applicable)
N/A