### PR TITLE
Wookie interface updates

### DIFF
--- a/pkg/authz/objecttype/handlers.go
+++ b/pkg/authz/objecttype/handlers.go
@@ -76,7 +76,7 @@ func CreateHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request
 		return err
 	}
 
-	createdObjectTypeSpec, err := svc.Create(r.Context(), objectTypeSpec)
+	createdObjectTypeSpec, _, err := svc.Create(r.Context(), objectTypeSpec)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func UpdateHandler(svc ObjectTypeService, w http.ResponseWriter, r *http.Request
 	}
 
 	typeId := mux.Vars(r)["type"]
-	updatedObjectTypeSpec, err := svc.UpdateByTypeId(r.Context(), typeId, objectTypeSpec)
+	updatedObjectTypeSpec, _, err := svc.UpdateByTypeId(r.Context(), typeId, objectTypeSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/objecttype/service.go
+++ b/pkg/authz/objecttype/service.go
@@ -35,11 +35,11 @@ func (m ObjectTypeMap) GetByTypeId(typeId string) (*ObjectTypeSpec, error) {
 }
 
 type Service interface {
-	Create(ctx context.Context, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error)
+	Create(ctx context.Context, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, *wookie.Token, error)
 	GetByTypeId(ctx context.Context, typeId string) (*ObjectTypeSpec, error)
 	GetTypeMap(ctx context.Context) (ObjectTypeMap, error)
 	List(ctx context.Context, listParams service.ListParams) ([]ObjectTypeSpec, error)
-	UpdateByTypeId(ctx context.Context, typeId string, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error)
+	UpdateByTypeId(ctx context.Context, typeId string, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, *wookie.Token, error)
 	DeleteByTypeId(ctx context.Context, typeId string) (*wookie.Token, error)
 }
 
@@ -57,7 +57,7 @@ func NewService(env service.Env, repository ObjectTypeRepository, eventSvc event
 	}
 }
 
-func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error) {
+func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, *wookie.Token, error) {
 	var newObjectTypeSpec *ObjectTypeSpec
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		_, err := svc.Repository.GetByTypeId(txCtx, objectTypeSpec.Type)
@@ -93,9 +93,9 @@ func (svc ObjectTypeService) Create(ctx context.Context, objectTypeSpec ObjectTy
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return newObjectTypeSpec, nil
+	return newObjectTypeSpec, nil, nil
 }
 
 func (svc ObjectTypeService) GetByTypeId(ctx context.Context, typeId string) (*ObjectTypeSpec, error) {
@@ -151,7 +151,7 @@ func (svc ObjectTypeService) List(ctx context.Context, listParams service.ListPa
 	return objectTypeSpecs, nil
 }
 
-func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, error) {
+func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, objectTypeSpec ObjectTypeSpec) (*ObjectTypeSpec, *wookie.Token, error) {
 	var updatedObjectTypeSpec *ObjectTypeSpec
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		currentObjectType, err := svc.Repository.GetByTypeId(txCtx, typeId)
@@ -182,9 +182,9 @@ func (svc ObjectTypeService) UpdateByTypeId(ctx context.Context, typeId string, 
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return updatedObjectTypeSpec, nil
+	return updatedObjectTypeSpec, nil, nil
 }
 
 func (svc ObjectTypeService) DeleteByTypeId(ctx context.Context, typeId string) (*wookie.Token, error) {

--- a/pkg/authz/warrant/handlers.go
+++ b/pkg/authz/warrant/handlers.go
@@ -69,7 +69,7 @@ func CreateHandler(svc WarrantService, w http.ResponseWriter, r *http.Request) e
 		}
 	}
 
-	createdWarrant, err := svc.Create(r.Context(), warrantSpec)
+	createdWarrant, _, err := svc.Create(r.Context(), warrantSpec)
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,7 @@ func DeleteHandler(svc WarrantService, w http.ResponseWriter, r *http.Request) e
 		return err
 	}
 
-	err = svc.Delete(r.Context(), warrantSpec)
+	_, err = svc.Delete(r.Context(), warrantSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -22,12 +22,13 @@ import (
 	"github.com/warrant-dev/warrant/pkg/event"
 	object "github.com/warrant-dev/warrant/pkg/object"
 	"github.com/warrant-dev/warrant/pkg/service"
+	"github.com/warrant-dev/warrant/pkg/wookie"
 )
 
 type Service interface {
-	Create(ctx context.Context, warrantSpec WarrantSpec) (*WarrantSpec, error)
+	Create(ctx context.Context, warrantSpec WarrantSpec) (*WarrantSpec, *wookie.Token, error)
 	List(ctx context.Context, filterParams *FilterParams, listParams service.ListParams) ([]WarrantSpec, error)
-	Delete(ctx context.Context, warrantSpec WarrantSpec) error
+	Delete(ctx context.Context, warrantSpec WarrantSpec) (*wookie.Token, error)
 }
 
 type WarrantService struct {
@@ -48,7 +49,7 @@ func NewService(env service.Env, repository WarrantRepository, eventSvc event.Se
 	}
 }
 
-func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (*WarrantSpec, error) {
+func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (*WarrantSpec, *wookie.Token, error) {
 	var createdWarrant Model
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		// Check that objectType is valid
@@ -143,10 +144,10 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return createdWarrant.ToWarrantSpec(), nil
+	return createdWarrant.ToWarrantSpec(), nil, nil
 }
 
 func (svc WarrantService) List(ctx context.Context, filterParams *FilterParams, listParams service.ListParams) ([]WarrantSpec, error) {
@@ -163,7 +164,7 @@ func (svc WarrantService) List(ctx context.Context, filterParams *FilterParams, 
 	return warrantSpecs, nil
 }
 
-func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) error {
+func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) (*wookie.Token, error) {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		warrantToDelete, err := warrantSpec.ToWarrant()
 		if err != nil {
@@ -194,8 +195,9 @@ func (svc WarrantService) Delete(ctx context.Context, warrantSpec WarrantSpec) e
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	//nolint:nilnil
+	return nil, nil
 }

--- a/pkg/authz/wookie/service.go
+++ b/pkg/authz/wookie/service.go
@@ -80,11 +80,11 @@ func (svc WookieService) GetLatestWookie(ctx context.Context) (*wookie.Token, er
 	return latestWookieToken, nil
 }
 
-func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(txCtx context.Context) error) (*wookie.Token, error) {
+func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(txCtx context.Context, createdWookieId int64) error) (*wookie.Token, error) {
 	serverCreatedWookie, hasServerCreatedWookie := ctx.Value(wookie.ServerCreatedWookieCtxKey{}).(*wookie.Token)
 	// An update is already in progress so continue with that ctx
 	if hasServerCreatedWookie {
-		e := txWookieFunc(ctx)
+		e := txWookieFunc(ctx, serverCreatedWookie.ID)
 		if e != nil {
 			return nil, e
 		}
@@ -101,7 +101,7 @@ func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(tx
 		}
 
 		wkCtx := context.WithValue(txCtx, wookie.ServerCreatedWookieCtxKey{}, newWookie)
-		err = txWookieFunc(wkCtx)
+		err = txWookieFunc(wkCtx, newWookie.ID)
 		if err != nil {
 			return err
 		}

--- a/pkg/authz/wookie/service.go
+++ b/pkg/authz/wookie/service.go
@@ -80,18 +80,18 @@ func (svc WookieService) GetLatestWookie(ctx context.Context) (*wookie.Token, er
 	return latestWookieToken, nil
 }
 
-func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(txCtx context.Context, newWookieId int64) error) (*wookie.Token, error) {
-	txnWookie, hasTxnWookie := ctx.Value(wookie.WookieTxKey{}).(*wookie.Token)
+func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(txCtx context.Context) error) (*wookie.Token, error) {
+	serverCreatedWookie, hasServerCreatedWookie := ctx.Value(wookie.ServerCreatedWookieCtxKey{}).(*wookie.Token)
 	// An update is already in progress so continue with that ctx
-	if hasTxnWookie {
-		e := txWookieFunc(ctx, txnWookie.ID)
+	if hasServerCreatedWookie {
+		e := txWookieFunc(ctx)
 		if e != nil {
 			return nil, e
 		}
-		return txnWookie, nil
+		return serverCreatedWookie, nil
 	}
 
-	// Otherwise create a new tx and new update wookie
+	// Otherwise, create a new tx and a new wookie for writes in txWookieFunc to use.
 	var newWookie *wookie.Token
 	var err error
 	err = svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
@@ -100,8 +100,8 @@ func (svc WookieService) WithNewWookie(ctx context.Context, txWookieFunc func(tx
 			return err
 		}
 
-		wkCtx := context.WithValue(txCtx, wookie.WookieTxKey{}, newWookie)
-		err = txWookieFunc(wkCtx, newWookie.ID)
+		wkCtx := context.WithValue(txCtx, wookie.ServerCreatedWookieCtxKey{}, newWookie)
+		err = txWookieFunc(wkCtx)
 		if err != nil {
 			return err
 		}

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -24,14 +24,14 @@ import (
 const HeaderName = "Warrant-Token"
 const Latest = "latest"
 
-type WookieCtxKey struct{}
-type WookieTxKey struct{}
+type ClientPassedWookieCtxKey struct{}
+type ServerCreatedWookieCtxKey struct{}
 
 func WookieMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headerVal := r.Header.Get(HeaderName)
 		if headerVal != "" {
-			wookieCtx := context.WithValue(r.Context(), WookieCtxKey{}, headerVal)
+			wookieCtx := context.WithValue(r.Context(), ClientPassedWookieCtxKey{}, headerVal)
 			next.ServeHTTP(w, r.WithContext(wookieCtx))
 			return
 		}
@@ -41,7 +41,7 @@ func WookieMiddleware(next http.Handler) http.Handler {
 
 // Returns true if ctx contains wookie set to 'latest', false otherwise.
 func ContainsLatest(ctx context.Context) bool {
-	if val, ok := ctx.Value(WookieCtxKey{}).(string); ok {
+	if val, ok := ctx.Value(ClientPassedWookieCtxKey{}).(string); ok {
 		if val == Latest {
 			return true
 		}
@@ -49,8 +49,8 @@ func ContainsLatest(ctx context.Context) bool {
 	return false
 }
 
-func GetWookieFromRequestContext(ctx context.Context) (string, error) {
-	wookieCtxVal := ctx.Value(WookieCtxKey{})
+func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error) {
+	wookieCtxVal := ctx.Value(ClientPassedWookieCtxKey{})
 	if wookieCtxVal == nil {
 		return "", nil
 	}
@@ -65,5 +65,5 @@ func GetWookieFromRequestContext(ctx context.Context) (string, error) {
 
 // Return a context with wookie set to 'latest'.
 func WithLatest(parent context.Context) context.Context {
-	return context.WithValue(parent, WookieCtxKey{}, Latest)
+	return context.WithValue(parent, ClientPassedWookieCtxKey{}, Latest)
 }

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -67,3 +67,9 @@ func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error
 func WithLatest(parent context.Context) context.Context {
 	return context.WithValue(parent, ClientPassedWookieCtxKey{}, Latest)
 }
+
+func AddAsResponseHeader(w http.ResponseWriter, token *Token) {
+	if token != nil {
+		w.Header().Set(HeaderName, token.String())
+	}
+}

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -49,6 +49,21 @@ func ContainsLatest(ctx context.Context) bool {
 	return false
 }
 
+func GetServerCreatedWookieFromRequestContext(ctx context.Context) (*Token, error) {
+	wookieCtxVal := ctx.Value(ServerCreatedWookieCtxKey{})
+	if wookieCtxVal == nil {
+		//nolint:nilnil
+		return nil, nil
+	}
+
+	wookieString, ok := wookieCtxVal.(*Token)
+	if !ok {
+		return nil, errors.New("error fetching server created wookie from request context")
+	}
+
+	return wookieString, nil
+}
+
 func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error) {
 	wookieCtxVal := ctx.Value(ClientPassedWookieCtxKey{})
 	if wookieCtxVal == nil {
@@ -57,7 +72,7 @@ func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error
 
 	wookieString, ok := wookieCtxVal.(string)
 	if !ok {
-		return "", errors.New("error fetching wookie from request context")
+		return "", errors.New("error fetching client passed wookie from request context")
 	}
 
 	return wookieString, nil

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -25,6 +25,7 @@ const HeaderName = "Warrant-Token"
 const Latest = "latest"
 
 type WookieCtxKey struct{}
+type WookieTxKey struct{}
 
 func WookieMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Describe your changes
This PR updates the `objecttype` and `warrant` Service interfaces to have the write methods return a wookie token in addition to the existing return values. This allows the wookie token to optionally be returned in the response. `WithNewWookie` is also created as a wrapper around `WithinTransaction`, where a new wookie is created, a transaction is started (or continued), and the new wookie is passed to the callback function.
