### PR TITLE
Add wookie middleware

### DIFF
--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -1,0 +1,63 @@
+// Copyright 2023 Forerunner Labs, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authz
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/warrant-dev/warrant/pkg/service"
+	"github.com/warrant-dev/warrant/pkg/wookie"
+)
+
+func GenerateWookieMiddleware(wookieSvc *WookieService) service.Middleware {
+	return func(next http.Handler) http.Handler {
+		return wookieMiddleware(next, wookieSvc)
+	}
+}
+
+func wookieMiddleware(next http.Handler, wookieSvc *WookieService) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, err := wookie.GetClientPassedWookieFromRequestContext(r.Context())
+		if err == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		headerVal := r.Header.Get(wookie.HeaderName)
+
+		switch headerVal {
+		case wookie.Latest:
+		case "":
+			token, err := wookieSvc.GetLatestWookie(r.Context())
+			if err != nil {
+				service.SendErrorResponse(w, service.NewInvalidRequestError("invalid warrant token"))
+				return
+			}
+
+			ctxWithToken := context.WithValue(r.Context(), wookie.ClientPassedWookieCtxKey{}, *token)
+			next.ServeHTTP(w, r.WithContext(ctxWithToken))
+		default:
+			token, err := wookie.FromString(headerVal)
+			if err != nil {
+				service.SendErrorResponse(w, service.NewInvalidRequestError("invalid warrant token"))
+				return
+			}
+
+			ctxWithToken := context.WithValue(r.Context(), wookie.ClientPassedWookieCtxKey{}, token)
+			next.ServeHTTP(w, r.WithContext(ctxWithToken))
+		}
+	})
+}

--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -52,7 +52,8 @@ func wookieMiddleware(next http.Handler, wookieSvc *WookieService) http.Handler 
 		default:
 			token, err := wookie.FromString(headerVal)
 			if err != nil {
-				service.SendErrorResponse(w, service.NewInvalidRequestError("invalid warrant token"))
+				hlog.FromRequest(r).Error().Err(err).Msg("wookie: error deserializing wookie from string")
+				service.SendErrorResponse(w, service.NewInternalError("Something went wrong"))
 				return
 			}
 

--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -42,7 +42,8 @@ func wookieMiddleware(next http.Handler, wookieSvc *WookieService) http.Handler 
 		case wookie.Latest, "":
 			token, err := wookieSvc.GetLatestWookie(r.Context())
 			if err != nil {
-				service.SendErrorResponse(w, service.NewInvalidRequestError("invalid warrant token"))
+				hlog.FromRequest(r).Error().Err(err).Msg("wookie: error fetching latest wookie")
+				service.SendErrorResponse(w, service.NewInternalError("Something went wrong"))
 				return
 			}
 

--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -39,8 +39,7 @@ func wookieMiddleware(next http.Handler, wookieSvc *WookieService) http.Handler 
 		headerVal := r.Header.Get(wookie.HeaderName)
 
 		switch headerVal {
-		case wookie.Latest:
-		case "":
+		case wookie.Latest, "":
 			token, err := wookieSvc.GetLatestWookie(r.Context())
 			if err != nil {
 				service.SendErrorResponse(w, service.NewInvalidRequestError("invalid warrant token"))

--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -30,8 +30,8 @@ func GenerateWookieMiddleware(wookieSvc *WookieService) service.Middleware {
 
 func wookieMiddleware(next http.Handler, wookieSvc *WookieService) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, err := wookie.GetClientPassedWookieFromRequestContext(r.Context())
-		if err == nil {
+		clientPassedWookieFromCtx, _ := wookie.GetClientPassedWookieFromRequestContext(r.Context())
+		if clientPassedWookieFromCtx != nil {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/pkg/authz/wookie/middleware.go
+++ b/pkg/authz/wookie/middleware.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/rs/zerolog/hlog"
 	"github.com/warrant-dev/warrant/pkg/service"
 	"github.com/warrant-dev/warrant/pkg/wookie"
 )

--- a/pkg/service/router.go
+++ b/pkg/service/router.go
@@ -75,7 +75,7 @@ func NewRouter(config config.Config, pathPrefix string, routes []Route, authMidd
 	}
 	router.Use(hlog.NewHandler(logger))
 	router.Use(stats.RequestStatsMiddleware)
-	router.Use(wookie.WookieMiddleware)
+	router.Use(wookie.WarrantTokenMiddleware)
 	if config.GetEnableAccessLog() {
 		router.Use(accessLogMiddleware)
 	}

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -24,14 +24,15 @@ import (
 const HeaderName = "Warrant-Token"
 const Latest = "latest"
 
+type WarrantTokenCtxKey struct{}
 type ClientPassedWookieCtxKey struct{}
 type ServerCreatedWookieCtxKey struct{}
 
-func WookieMiddleware(next http.Handler) http.Handler {
+func WarrantTokenMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headerVal := r.Header.Get(HeaderName)
 		if headerVal != "" {
-			wookieCtx := context.WithValue(r.Context(), ClientPassedWookieCtxKey{}, headerVal)
+			wookieCtx := context.WithValue(r.Context(), WarrantTokenCtxKey{}, headerVal)
 			next.ServeHTTP(w, r.WithContext(wookieCtx))
 			return
 		}
@@ -41,7 +42,7 @@ func WookieMiddleware(next http.Handler) http.Handler {
 
 // Returns true if ctx contains wookie set to 'latest', false otherwise.
 func ContainsLatest(ctx context.Context) bool {
-	if val, ok := ctx.Value(ClientPassedWookieCtxKey{}).(string); ok {
+	if val, ok := ctx.Value(WarrantTokenCtxKey{}).(string); ok {
 		if val == Latest {
 			return true
 		}
@@ -80,7 +81,7 @@ func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error
 
 // Return a context with wookie set to 'latest'.
 func WithLatest(parent context.Context) context.Context {
-	return context.WithValue(parent, ClientPassedWookieCtxKey{}, Latest)
+	return context.WithValue(parent, WarrantTokenCtxKey{}, Latest)
 }
 
 func AddAsResponseHeader(w http.ResponseWriter, token *Token) {

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -57,26 +57,27 @@ func GetServerCreatedWookieFromRequestContext(ctx context.Context) (*Token, erro
 		return nil, nil
 	}
 
-	wookieString, ok := wookieCtxVal.(*Token)
+	wookieToken, ok := wookieCtxVal.(*Token)
 	if !ok {
 		return nil, errors.New("error fetching server created wookie from request context")
 	}
 
-	return wookieString, nil
+	return wookieToken, nil
 }
 
-func GetClientPassedWookieFromRequestContext(ctx context.Context) (string, error) {
+func GetClientPassedWookieFromRequestContext(ctx context.Context) (*Token, error) {
 	wookieCtxVal := ctx.Value(ClientPassedWookieCtxKey{})
 	if wookieCtxVal == nil {
-		return "", nil
+		//nolint:nilnil
+		return nil, nil
 	}
 
-	wookieString, ok := wookieCtxVal.(string)
+	wookieToken, ok := wookieCtxVal.(*Token)
 	if !ok {
-		return "", errors.New("error fetching client passed wookie from request context")
+		return nil, errors.New("error fetching client passed wookie from request context")
 	}
 
-	return wookieString, nil
+	return wookieToken, nil
 }
 
 // Return a context with wookie set to 'latest'.

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -57,12 +57,12 @@ func GetServerCreatedWookieFromRequestContext(ctx context.Context) (*Token, erro
 		return nil, nil
 	}
 
-	wookieToken, ok := wookieCtxVal.(*Token)
+	wookieToken, ok := wookieCtxVal.(Token)
 	if !ok {
 		return nil, errors.New("error fetching server created wookie from request context")
 	}
 
-	return wookieToken, nil
+	return &wookieToken, nil
 }
 
 func GetClientPassedWookieFromRequestContext(ctx context.Context) (*Token, error) {
@@ -72,12 +72,12 @@ func GetClientPassedWookieFromRequestContext(ctx context.Context) (*Token, error
 		return nil, nil
 	}
 
-	wookieToken, ok := wookieCtxVal.(*Token)
+	wookieToken, ok := wookieCtxVal.(Token)
 	if !ok {
 		return nil, errors.New("error fetching client passed wookie from request context")
 	}
 
-	return wookieToken, nil
+	return &wookieToken, nil
 }
 
 // Return a context with wookie set to 'latest'.

--- a/pkg/wookie/wookie.go
+++ b/pkg/wookie/wookie.go
@@ -32,8 +32,8 @@ func WarrantTokenMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		headerVal := r.Header.Get(HeaderName)
 		if headerVal != "" {
-			wookieCtx := context.WithValue(r.Context(), WarrantTokenCtxKey{}, headerVal)
-			next.ServeHTTP(w, r.WithContext(wookieCtx))
+			warrantTokenCtx := context.WithValue(r.Context(), WarrantTokenCtxKey{}, headerVal)
+			next.ServeHTTP(w, r.WithContext(warrantTokenCtx))
 			return
 		}
 		next.ServeHTTP(w, r)


### PR DESCRIPTION
## Describe your changes
This PR renames the existing wookie middleware and a new wookie middleware (`WookieMiddleware`) which fetches the wookie token and sets it in the request context.

The current wookie middlename is renamed from `WookieMiddleware` to `WarrantTokenMiddleware` and simply sets the `Warrant-Token` header value in context. This allows queries to be handled appropriately by either the reader or writer instance. The new wookie middleware `WookieMiddleware` can be applied to applicable endpoints and fetches/parses the token and sets it in context.

## Issue number and link (if applicable)
