### PR TITLE
Add tests for duplicate record creation

### DIFF
--- a/tests/authz-policy.json
+++ b/tests/authz-policy.json
@@ -147,6 +147,36 @@
             }
         },
         {
+            "name": "createDuplicateWarrantWithPolicy",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "policy": "clientIp matches \"192\\\\.168\\\\..*\\\\..*\""
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "cluster",
+                    "objectId": "us-east-1",
+                    "relation": "editor",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "user-a"
+                    },
+                    "policy": "clientIp matches \"192\\\\.168\\\\..*\\\\..*\""
+                }
+            }
+        },
+        {
             "name": "checkUserIsEditorOfCluster",
             "request": {
                 "method": "POST",

--- a/tests/objects-crud.json
+++ b/tests/objects-crud.json
@@ -81,6 +81,24 @@
             }
         },
         {
+            "name": "createDuplicateObject2",
+            "request": {
+                "method": "POST",
+                "url": "/v1/objects",
+                "body": {
+                    "objectType": "test",
+                    "objectId": "second-object"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "test",
+                    "objectId": "second-object"
+                }
+            }
+        },
+        {
             "name": "getObjectById",
             "request": {
                 "method": "GET",
@@ -105,6 +123,10 @@
                 "body": [
                     {
                         "objectType": "test",
+                        "objectId": "second-object"
+                    },
+                    {
+                        "objectType": "test",
                         "objectId": "third-object",
                         "meta": {
                             "myKey": "myVal"
@@ -113,10 +135,6 @@
                     {
                         "objectType": "test",
                         "objectId": "{{ createObjectWithGeneratedId.objectId }}"
-                    },
-                    {
-                        "objectType": "test",
-                        "objectId": "second-object"
                     },
                     {
                         "objectType": "test",

--- a/tests/warrants-crud.json
+++ b/tests/warrants-crud.json
@@ -80,6 +80,34 @@
             }
         },
         {
+            "name": "createDuplicateWarrant",
+            "request": {
+                "method": "POST",
+                "url": "/v1/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-balance-sheet",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "senior-accountant"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-balance-sheet",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "senior-accountant"
+                    }
+                }
+            }
+        },
+        {
             "name": "assignPermissionEditBalanceSheetToUserUsera",
             "request": {
                 "method": "POST",


### PR DESCRIPTION
## Describe your changes
This PR adds tests for duplicate record creation for objects, object types, and warrants. Instead of erroring out, these endpoints will update the `createdAt` and `updatedAt` of the existing record.

