### PR TITLE
Add objectType validation to CreateObjectSpec

### DIFF
--- a/pkg/object/spec.go
+++ b/pkg/object/spec.go
@@ -56,7 +56,7 @@ func (spec ObjectSpec) ToObject() (*Object, error) {
 }
 
 type CreateObjectSpec struct {
-	ObjectType string                 `json:"objectType" validate:"required"`
+	ObjectType string                 `json:"objectType" validate:"required,valid_object_type"`
 	ObjectId   string                 `json:"objectId"   validate:"omitempty,valid_object_id"`
 	Meta       map[string]interface{} `json:"meta"`
 }

--- a/tests/objects-crud.json
+++ b/tests/objects-crud.json
@@ -22,6 +22,44 @@
             }
         },
         {
+            "name": "createObjectInvalidObjectType",
+            "request": {
+                "method": "POST",
+                "url": "/v1/objects",
+                "body": {
+                    "objectType": "test$$&-",
+                    "objectId": "second-object"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 400,
+                "body": {
+                    "code": "invalid_parameter",
+                    "parameter": "objectType",
+                    "message": "can only contain lower-case alphanumeric characters and/or '-' and '_'"
+                }
+            }
+        },
+        {
+            "name": "createObjectInvalidObjectId",
+            "request": {
+                "method": "POST",
+                "url": "/v1/objects",
+                "body": {
+                    "objectType": "test",
+                    "objectId": "second-object$$^"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 400,
+                "body": {
+                    "code": "invalid_parameter",
+                    "parameter": "objectId",
+                    "message": "can only contain alphanumeric characters and/or '-', '_', '@', ':', and '|'"
+                }
+            }
+        },
+        {
             "name": "createObject2",
             "request": {
                 "method": "POST",


### PR DESCRIPTION
## Describe your changes
This PR adds validation to the `objectType` field of `CreateObjectSpec` to ensure valid object types when creating objects.

