### PR TITLE
Return wookie from object delete method

### DIFF
--- a/pkg/object/feature/service.go
+++ b/pkg/object/feature/service.go
@@ -115,7 +115,7 @@ func (svc FeatureService) UpdateByFeatureId(ctx context.Context, featureId strin
 }
 
 func (svc FeatureService) DeleteByFeatureId(ctx context.Context, featureId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeFeature, featureId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeFeature, featureId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/handlers.go
+++ b/pkg/object/handlers.go
@@ -134,7 +134,7 @@ func UpdateHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) er
 func DeleteHandler(svc ObjectService, w http.ResponseWriter, r *http.Request) error {
 	objectType := mux.Vars(r)["objectType"]
 	objectId := mux.Vars(r)["objectId"]
-	err := svc.DeleteByObjectTypeAndId(r.Context(), objectType, objectId)
+	_, err := svc.DeleteByObjectTypeAndId(r.Context(), objectType, objectId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/permission/service.go
+++ b/pkg/object/permission/service.go
@@ -117,7 +117,7 @@ func (svc PermissionService) UpdateByPermissionId(ctx context.Context, permissio
 }
 
 func (svc PermissionService) DeleteByPermissionId(ctx context.Context, permissionId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypePermission, permissionId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypePermission, permissionId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/pricingtier/service.go
+++ b/pkg/object/pricingtier/service.go
@@ -117,7 +117,7 @@ func (svc PricingTierService) UpdateByPricingTierId(ctx context.Context, pricing
 }
 
 func (svc PricingTierService) DeleteByPricingTierId(ctx context.Context, pricingTierId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypePricingTier, pricingTierId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypePricingTier, pricingTierId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/role/service.go
+++ b/pkg/object/role/service.go
@@ -117,7 +117,7 @@ func (svc RoleService) UpdateByRoleId(ctx context.Context, roleId string, roleSp
 }
 
 func (svc RoleService) DeleteByRoleId(ctx context.Context, roleId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeRole, roleId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeRole, roleId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/service.go
+++ b/pkg/object/service.go
@@ -17,6 +17,8 @@ package object
 import (
 	"context"
 
+	"github.com/warrant-dev/warrant/pkg/wookie"
+
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/warrant-dev/warrant/pkg/event"
@@ -29,7 +31,7 @@ type Service interface {
 	BatchGetByObjectTypeAndIds(ctx context.Context, objectType string, objectIds []string) ([]ObjectSpec, error)
 	List(ctx context.Context, filterOptions *FilterOptions, listParams service.ListParams) ([]ObjectSpec, error)
 	UpdateByObjectTypeAndId(ctx context.Context, objectType string, objectId string, updateSpec UpdateObjectSpec) (*ObjectSpec, error)
-	DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error
+	DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (*wookie.Token, error)
 }
 
 type ObjectService struct {
@@ -183,7 +185,7 @@ func (svc ObjectService) UpdateByObjectTypeAndId(ctx context.Context, objectType
 	return updatedObjectSpec, nil
 }
 
-func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) error {
+func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType string, objectId string) (*wookie.Token, error) {
 	err := svc.Env().DB().WithinTransaction(ctx, func(txCtx context.Context) error {
 		objectSpec, err := svc.GetByObjectTypeAndId(txCtx, objectType, objectId)
 		if err != nil {
@@ -216,7 +218,9 @@ func (svc ObjectService) DeleteByObjectTypeAndId(ctx context.Context, objectType
 	})
 
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+
+	//nolint:nilnil
+	return nil, nil
 }

--- a/pkg/object/tenant/service.go
+++ b/pkg/object/tenant/service.go
@@ -117,7 +117,7 @@ func (svc TenantService) UpdateByTenantId(ctx context.Context, tenantId string, 
 }
 
 func (svc TenantService) DeleteByTenantId(ctx context.Context, tenantId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeTenant, tenantId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeTenant, tenantId)
 	if err != nil {
 		return err
 	}

--- a/pkg/object/user/service.go
+++ b/pkg/object/user/service.go
@@ -117,7 +117,7 @@ func (svc UserService) UpdateByUserId(ctx context.Context, userId string, userSp
 }
 
 func (svc UserService) DeleteByUserId(ctx context.Context, userId string) error {
-	err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeUser, userId)
+	_, err := svc.ObjectSvc.DeleteByObjectTypeAndId(ctx, objecttype.ObjectTypeUser, userId)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Describe your changes
Updates the object service's delete method to return a wookie because it cascade deletes warrants related to the object.

## Issue number and link (if applicable)
N/A