### PR TITLE
Add spec from query result methods

### DIFF
--- a/pkg/object/feature/spec.go
+++ b/pkg/object/feature/spec.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pkg/errors"
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -58,6 +59,38 @@ func NewFeatureSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*FeatureSpec, 
 		Name:        name,
 		Description: description,
 		CreatedAt:   objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewFeatureSpecFromQueryResult(queryResult *query.QueryResult) (*FeatureSpec, error) {
+	var (
+		name        *string
+		description *string
+	)
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["name"]; exists {
+			nameStr, ok := queryResult.Meta["name"].(string)
+			if !ok {
+				return nil, errors.New("feature name has invalid type in result meta")
+			}
+			name = &nameStr
+		}
+
+		if _, exists := queryResult.Meta["description"]; exists {
+			descriptionStr, ok := queryResult.Meta["description"].(string)
+			if !ok {
+				return nil, errors.New("feature description has invalid type in result meta")
+			}
+			description = &descriptionStr
+		}
+	}
+
+	return &FeatureSpec{
+		FeatureId:   queryResult.ObjectId,
+		Name:        name,
+		Description: description,
+		CreatedAt:   queryResult.Warrant.CreatedAt,
 	}, nil
 }
 

--- a/pkg/object/permission/spec.go
+++ b/pkg/object/permission/spec.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -58,6 +59,38 @@ func NewPermissionSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*Permission
 		Name:         name,
 		Description:  description,
 		CreatedAt:    objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewPermissionSpecFromQueryResult(queryResult *query.QueryResult) (*PermissionSpec, error) {
+	var (
+		name        *string
+		description *string
+	)
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["name"]; exists {
+			nameStr, ok := queryResult.Meta["name"].(string)
+			if !ok {
+				return nil, errors.New("permission name has invalid type in result meta")
+			}
+			name = &nameStr
+		}
+
+		if _, exists := queryResult.Meta["description"]; exists {
+			descriptionStr, ok := queryResult.Meta["description"].(string)
+			if !ok {
+				return nil, errors.New("permission description has invalid type in result meta")
+			}
+			description = &descriptionStr
+		}
+	}
+
+	return &PermissionSpec{
+		PermissionId: queryResult.ObjectId,
+		Name:         name,
+		Description:  description,
+		CreatedAt:    queryResult.Warrant.CreatedAt,
 	}, nil
 }
 

--- a/pkg/object/pricingtier/spec.go
+++ b/pkg/object/pricingtier/spec.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -58,6 +59,38 @@ func NewPricingTierSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*PricingTi
 		Name:          name,
 		Description:   description,
 		CreatedAt:     objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewPricingTierSpecFromQueryResult(queryResult *query.QueryResult) (*PricingTierSpec, error) {
+	var (
+		name        *string
+		description *string
+	)
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["name"]; exists {
+			nameStr, ok := queryResult.Meta["name"].(string)
+			if !ok {
+				return nil, errors.New("pricing tier name has invalid type in result meta")
+			}
+			name = &nameStr
+		}
+
+		if _, exists := queryResult.Meta["description"]; exists {
+			descriptionStr, ok := queryResult.Meta["description"].(string)
+			if !ok {
+				return nil, errors.New("pricing tier description has invalid type in result meta")
+			}
+			description = &descriptionStr
+		}
+	}
+
+	return &PricingTierSpec{
+		PricingTierId: queryResult.ObjectId,
+		Name:          name,
+		Description:   description,
+		CreatedAt:     queryResult.Warrant.CreatedAt,
 	}, nil
 }
 

--- a/pkg/object/role/spec.go
+++ b/pkg/object/role/spec.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -58,6 +59,38 @@ func NewRoleSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*RoleSpec, error)
 		Name:        name,
 		Description: description,
 		CreatedAt:   objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewRoleSpecFromQueryResult(queryResult *query.QueryResult) (*RoleSpec, error) {
+	var (
+		name        *string
+		description *string
+	)
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["name"]; exists {
+			nameStr, ok := queryResult.Meta["name"].(string)
+			if !ok {
+				return nil, errors.New("role name has invalid type in result meta")
+			}
+			name = &nameStr
+		}
+
+		if _, exists := queryResult.Meta["description"]; exists {
+			descriptionStr, ok := queryResult.Meta["description"].(string)
+			if !ok {
+				return nil, errors.New("role description has invalid type in result meta")
+			}
+			description = &descriptionStr
+		}
+	}
+
+	return &RoleSpec{
+		RoleId:      queryResult.ObjectId,
+		Name:        name,
+		Description: description,
+		CreatedAt:   queryResult.Warrant.CreatedAt,
 	}, nil
 }
 

--- a/pkg/object/tenant/spec.go
+++ b/pkg/object/tenant/spec.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -45,6 +46,26 @@ func NewTenantSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*TenantSpec, er
 		TenantId:  objectSpec.ObjectId,
 		Name:      name,
 		CreatedAt: objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewTenantSpecFromQueryResult(queryResult *query.QueryResult) (*TenantSpec, error) {
+	var name *string
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["name"]; exists {
+			nameStr, ok := queryResult.Meta["name"].(string)
+			if !ok {
+				return nil, errors.New("tenant name has invalid type in result meta")
+			}
+			name = &nameStr
+		}
+	}
+
+	return &TenantSpec{
+		TenantId:  queryResult.ObjectId,
+		Name:      name,
+		CreatedAt: queryResult.Warrant.CreatedAt,
 	}, nil
 }
 

--- a/pkg/object/user/spec.go
+++ b/pkg/object/user/spec.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	objecttype "github.com/warrant-dev/warrant/pkg/authz/objecttype"
+	query "github.com/warrant-dev/warrant/pkg/authz/query"
 	object "github.com/warrant-dev/warrant/pkg/object"
 )
 
@@ -45,6 +46,26 @@ func NewUserSpecFromObjectSpec(objectSpec *object.ObjectSpec) (*UserSpec, error)
 		UserId:    objectSpec.ObjectId,
 		Email:     email,
 		CreatedAt: objectSpec.CreatedAt,
+	}, nil
+}
+
+func NewUserSpecFromQueryResult(queryResult *query.QueryResult) (*UserSpec, error) {
+	var email *string
+
+	if queryResult.Meta != nil {
+		if _, exists := queryResult.Meta["email"]; exists {
+			emailStr, ok := queryResult.Meta["email"].(string)
+			if !ok {
+				return nil, errors.New("user email has invalid type in result meta")
+			}
+			email = &emailStr
+		}
+	}
+
+	return &UserSpec{
+		UserId:    queryResult.ObjectId,
+		Email:     email,
+		CreatedAt: queryResult.Warrant.CreatedAt,
 	}, nil
 }
 


### PR DESCRIPTION
## Describe your changes
This PR adds `XSpecFromQueryResult` methods, which can convert a query result into either a `FeatureSpec`, `PricingTierSpec`, `PermissionSpec`, `RoleSpec`, `TenantSpec`, or `UserSpec`.

