### PR TITLE
Update create queries to only createdAt when record is deleted

### DIFF
--- a/pkg/authz/objecttype/mysql.go
+++ b/pkg/authz/objecttype/mysql.go
@@ -44,7 +44,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 			) VALUES (?, ?)
 			ON DUPLICATE KEY UPDATE
 				definition = ?,
-				createdAt = CURRENT_TIMESTAMP(6),
+				createdAt = IF(objectType.deletedAt IS NULL, objectType.createdAt, CURRENT_TIMESTAMP(6)),
 				updatedAt = CURRENT_TIMESTAMP(6),
 				deletedAt = NULL
 		`,

--- a/pkg/authz/objecttype/postgres.go
+++ b/pkg/authz/objecttype/postgres.go
@@ -49,7 +49,10 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?)
 			ON CONFLICT (type_id) DO UPDATE SET
 				definition = ?,
-				created_at = CURRENT_TIMESTAMP(6),
+				created_at = CASE
+					WHEN object_type.deleted_at IS NULL THEN object_type.created_at
+					ELSE CURRENT_TIMESTAMP(6)
+				END,
 				updated_at = CURRENT_TIMESTAMP(6),
 				deleted_at = NULL
 			RETURNING id

--- a/pkg/authz/objecttype/sqlite.go
+++ b/pkg/authz/objecttype/sqlite.go
@@ -50,7 +50,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 			) VALUES (?, ?, ?, ?)
 			ON CONFLICT (typeId) DO UPDATE SET
 				definition = ?,
-				createdAt = ?,
+				createdAt = IIF(objectType.deletedAt IS NULL, objectType.createdAt, ?),
 				updatedAt = ?,
 				deletedAt = NULL
 			RETURNING id

--- a/pkg/authz/warrant/mysql.go
+++ b/pkg/authz/warrant/mysql.go
@@ -49,7 +49,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 				policyHash
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			ON DUPLICATE KEY UPDATE
-				createdAt = CURRENT_TIMESTAMP(6),
+				createdAt = IF(warrant.deletedAt IS NULL, warrant.createdAt, CURRENT_TIMESTAMP(6)),
 				updatedAt = CURRENT_TIMESTAMP(6),
 				deletedAt = NULL
 		`,

--- a/pkg/authz/warrant/postgres.go
+++ b/pkg/authz/warrant/postgres.go
@@ -54,7 +54,10 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 				policy_hash
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (object_type, object_id, relation, subject_type, subject_id, subject_relation, policy_hash) DO UPDATE SET
-				created_at = CURRENT_TIMESTAMP(6),
+				created_at = CASE
+					WHEN warrant.deleted_at IS NULL THEN warrant.created_at
+					ELSE CURRENT_TIMESTAMP(6)
+				END,
 				updated_at = CURRENT_TIMESTAMP(6),
 				deleted_at = NULL
 			RETURNING id

--- a/pkg/authz/warrant/sqlite.go
+++ b/pkg/authz/warrant/sqlite.go
@@ -55,7 +55,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 				updatedAt
 			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 			ON CONFLICT (objectType, objectId, relation, subjectType, subjectId, subjectRelation, policyHash) DO UPDATE SET
-				createdAt = ?,
+				createdAt = IIF(warrant.deletedAt IS NULL, warrant.createdAt, ?),
 				updatedAt = ?,
 				deletedAt = NULL
 			RETURNING id

--- a/pkg/object/mysql.go
+++ b/pkg/object/mysql.go
@@ -46,7 +46,7 @@ func (repo MySQLRepository) Create(ctx context.Context, model Model) (int64, err
 			) VALUES (?, ?, ?)
 			ON DUPLICATE KEY UPDATE
 				meta = ?,
-				createdAt = CURRENT_TIMESTAMP(6),
+				createdAt = IF(object.deletedAt IS NULL, object.createdAt, CURRENT_TIMESTAMP(6)),
 				updatedAt = CURRENT_TIMESTAMP(6),
 				deletedAt = NULL
 		`,

--- a/pkg/object/postgres.go
+++ b/pkg/object/postgres.go
@@ -51,7 +51,10 @@ func (repo PostgresRepository) Create(ctx context.Context, model Model) (int64, 
 			) VALUES (?, ?, ?)
 			ON CONFLICT (object_type, object_id) DO UPDATE SET
 				meta = ?,
-				created_at = CURRENT_TIMESTAMP(6),
+				created_at = CASE
+					WHEN object.deleted_at IS NULL THEN object.created_at
+					ELSE CURRENT_TIMESTAMP(6)
+				END,
 				updated_at = CURRENT_TIMESTAMP(6),
 				deleted_at = NULL
 			RETURNING id

--- a/pkg/object/sqlite.go
+++ b/pkg/object/sqlite.go
@@ -52,7 +52,7 @@ func (repo SQLiteRepository) Create(ctx context.Context, model Model) (int64, er
 			) VALUES (?, ?, ?, ?, ?)
 			ON CONFLICT (objectType, objectId) DO UPDATE SET
 				meta = ?,
-				createdAt = ?,
+				createdAt = IIF(object.deletedAt IS NULL, object.createdAt, ?),
 				updatedAt = ?,
 				deletedAt = NULL
 			RETURNING id

--- a/tests/objects-crud.json
+++ b/tests/objects-crud.json
@@ -161,10 +161,6 @@
                 "body": [
                     {
                         "objectType": "test",
-                        "objectId": "second-object"
-                    },
-                    {
-                        "objectType": "test",
                         "objectId": "third-object",
                         "meta": {
                             "myKey": "myVal"
@@ -173,6 +169,10 @@
                     {
                         "objectType": "test",
                         "objectId": "{{ createObjectWithGeneratedId.objectId }}"
+                    },
+                    {
+                        "objectType": "test",
+                        "objectId": "second-object"
                     },
                     {
                         "objectType": "test",


### PR DESCRIPTION
## Describe your changes
If a duplicate key is encountered during an INSERT query, the `createdAt` is always updated regardless if the record is currently deleted or not. This PR updates the create queries for the `object`, `objectType` and `warrant` tables to only update the `createdAt` when the record is currently deleted.

## Issue number and link (if applicable)
