### PR TITLE
Ignore wildcard subject objectIds when creating warrant objects

### DIFF
--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -69,7 +69,7 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 		}
 
 		// Unless objectId is wildcard, create referenced object if it does not already exist
-		if warrantSpec.ObjectId != "*" {
+		if warrantSpec.ObjectId != Wildcard {
 			objectSpec, err := svc.ObjectSvc.GetByObjectTypeAndId(txCtx, warrantSpec.ObjectType, warrantSpec.ObjectId)
 			if err != nil {
 				var recordNotFoundError *service.RecordNotFoundError
@@ -93,7 +93,7 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 		}
 
 		// Unless subject objectId is wildcard, create referenced subject if it does not already exist
-		if warrantSpec.Subject.ObjectId != "*" {
+		if warrantSpec.Subject.ObjectId != Wildcard {
 			objectSpec, err := svc.ObjectSvc.GetByObjectTypeAndId(txCtx, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId)
 			if err != nil {
 				var recordNotFoundError *service.RecordNotFoundError

--- a/pkg/authz/warrant/service.go
+++ b/pkg/authz/warrant/service.go
@@ -92,24 +92,26 @@ func (svc WarrantService) Create(ctx context.Context, warrantSpec WarrantSpec) (
 			}
 		}
 
-		// Create referenced subject if it does not already exist
-		objectSpec, err := svc.ObjectSvc.GetByObjectTypeAndId(txCtx, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId)
-		if err != nil {
-			var recordNotFoundError *service.RecordNotFoundError
-			if !errors.As(err, &recordNotFoundError) {
-				return err
-			}
-		}
-
-		if objectSpec == nil {
-			_, err = svc.ObjectSvc.Create(txCtx, object.CreateObjectSpec{
-				ObjectType: warrantSpec.Subject.ObjectType,
-				ObjectId:   warrantSpec.Subject.ObjectId,
-			})
+		// Unless subject objectId is wildcard, create referenced subject if it does not already exist
+		if warrantSpec.Subject.ObjectId != "*" {
+			objectSpec, err := svc.ObjectSvc.GetByObjectTypeAndId(txCtx, warrantSpec.Subject.ObjectType, warrantSpec.Subject.ObjectId)
 			if err != nil {
-				var duplicateRecordError *service.DuplicateRecordError
-				if !errors.As(err, &duplicateRecordError) {
+				var recordNotFoundError *service.RecordNotFoundError
+				if !errors.As(err, &recordNotFoundError) {
 					return err
+				}
+			}
+
+			if objectSpec == nil {
+				_, err = svc.ObjectSvc.Create(txCtx, object.CreateObjectSpec{
+					ObjectType: warrantSpec.Subject.ObjectType,
+					ObjectId:   warrantSpec.Subject.ObjectId,
+				})
+				if err != nil {
+					var duplicateRecordError *service.DuplicateRecordError
+					if !errors.As(err, &duplicateRecordError) {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Describe your changes
This PR updates the automatic object creation when creating a warrant to ignore the subject if the objectId is a wildcard.

## Issue number and link (if applicable)
