### PR TITLE
Filter query results by the specified subject type(s) when selecting subjects

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,7 +63,7 @@ linters:
 linters-settings:
   goheader:
     template: |-
-      Copyright {{YEAR-RANGE}} Forerunner Labs, Inc.
+      Copyright 2023 Forerunner Labs, Inc.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/pkg/authz/query/service.go
+++ b/pkg/authz/query/service.go
@@ -345,7 +345,7 @@ func (svc QueryService) matchRelation(ctx context.Context, selectSubjects bool, 
 					}
 				}
 			}
-		} else if selectSubjects {
+		} else if selectSubjects && matches(matchFilters.SubjectType, matchedWarrant.Subject.ObjectType) {
 			resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, matchedWarrant, level > 0)
 		} else if matches(matchFilters.SubjectType, matchedWarrant.Subject.ObjectType) && matches(matchFilters.SubjectId, matchedWarrant.Subject.ObjectId) {
 			resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, matchedWarrant, level > 0)

--- a/tests/v2/query.json
+++ b/tests/v2/query.json
@@ -1792,6 +1792,214 @@
             "expectedResponse": {
                 "statusCode": 200
             }
+        },
+        {
+            "name": "assignRoleDeveloperMemberOfPermissionViewDocs",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-docs",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "developer"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-docs",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "developer"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleManagerMemberOfRoleDeveloper",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "developer",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "developer",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignUserRichardMemberOfRoleDeveloper",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "developer",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "richard"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "developer",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "richard"
+                    }
+                }
+            }
+        },
+        {
+            "name": "selectMembersOfTypeUserForPermissionViewDocs",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20member%20of%20type%20user%20for%20permission:view-docs"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "user",
+                            "objectId": "richard",
+                            "warrant": {
+                                "objectType": "role",
+                                "objectId": "developer",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "richard"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectMembersOfAnyTypeForPermissionViewDocs",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20member%20of%20type%20%2A%20for%20permission:view-docs"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "role",
+                            "objectId": "developer",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-docs",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "developer"
+                                }
+                            },
+                            "isImplicit": false
+                        },
+                        {
+                            "objectType": "role",
+                            "objectId": "manager",
+                            "warrant": {
+                                "objectType": "role",
+                                "objectId": "developer",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "user",
+                            "objectId": "richard",
+                            "warrant": {
+                                "objectType": "role",
+                                "objectId": "developer",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "richard"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "deleteUserRichard",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/richard"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleManager",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/manager"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleDeveloper",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/developer"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionViewDocs",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/view-docs"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
         }
     ]
 }


### PR DESCRIPTION
## Describe your changes
When selecting a set of subjects using a query like `select member of type user for permission:A`, the query API returns results of types other than just `user`. This PR updates the query API to only return results of the specified subject type(s) if specified.

## Issue number and link (if applicable)
N/A