### PR TITLE
Pin version of `golangci-lint` to `v1.55` (include patches) in GitHub workflow

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.55
           args: -v --timeout=5m
           only-new-issues: false
           install-mode: "binary"


### PR DESCRIPTION
## Describe your changes

## Issue number and link (if applicable)
