### PR TITLE
Add policy support to query endpoint

### DIFF
--- a/pkg/authz/query/handlers.go
+++ b/pkg/authz/query/handlers.go
@@ -42,10 +42,18 @@ func (svc QueryService) Routes() ([]service.Route, error) {
 }
 
 func queryV1(svc QueryService, w http.ResponseWriter, r *http.Request) error {
-	queryString := r.URL.Query().Get("q")
+	queryParams := r.URL.Query()
+	queryString := queryParams.Get("q")
 	query, err := NewQueryFromString(queryString)
 	if err != nil {
 		return err
+	}
+
+	if queryParams.Has("context") {
+		err = query.WithContext(queryParams.Get("context"))
+		if err != nil {
+			return service.NewInvalidParameterError("context", "invalid")
+		}
 	}
 
 	listParams := service.GetListParamsFromContext[QueryListParamParser](r.Context())
@@ -88,10 +96,18 @@ func queryV1(svc QueryService, w http.ResponseWriter, r *http.Request) error {
 }
 
 func queryV2(svc QueryService, w http.ResponseWriter, r *http.Request) error {
-	queryString := r.URL.Query().Get("q")
+	queryParams := r.URL.Query()
+	queryString := queryParams.Get("q")
 	query, err := NewQueryFromString(queryString)
 	if err != nil {
 		return err
+	}
+
+	if queryParams.Has("context") {
+		err = query.WithContext(queryParams.Get("context"))
+		if err != nil {
+			return service.NewInvalidParameterError("context", "invalid")
+		}
 	}
 
 	listParams := service.GetListParamsFromContext[QueryListParamParser](r.Context())

--- a/pkg/authz/query/parser.go
+++ b/pkg/authz/query/parser.go
@@ -176,6 +176,5 @@ func NewQueryFromString(queryString string) (Query, error) {
 		}
 	}
 
-	query.rawString = queryString
 	return query, nil
 }

--- a/pkg/authz/query/service.go
+++ b/pkg/authz/query/service.go
@@ -368,6 +368,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 						continue
 					}
 
+					policy := matchedWarrant.Policy.And(sub.Policy)
 					if matchedWarrant.ObjectId == warrant.Wildcard {
 						expandedObjects, err := svc.listObjectsByType(ctx, matchedWarrant.ObjectType)
 						if err != nil {
@@ -375,10 +376,10 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 						}
 
 						for _, obj := range expandedObjects {
-							resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
+							resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, policy, sub.IsImplicit || level > 0)
 						}
 					} else {
-						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
+						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, policy, sub.IsImplicit || level > 0)
 					}
 				}
 			} else if query.SelectObjects.WhereSubject == nil ||
@@ -454,7 +455,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 				}
 
 				for sub := subset.List(); sub != nil; sub = sub.Next() {
-					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
+					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, matchedWarrant.Policy.And(sub.Policy), sub.IsImplicit || level > 0)
 				}
 			} else if query.SelectSubjects.SubjectTypes[0] == matchedWarrant.Subject.ObjectType {
 				resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false)

--- a/pkg/authz/query/service.go
+++ b/pkg/authz/query/service.go
@@ -114,7 +114,7 @@ func (svc QueryService) Query(ctx context.Context, query Query, listParams servi
 				}
 
 				for res := queryResult.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit, MergeOpOr)
 				}
 			}
 		}
@@ -175,7 +175,7 @@ func (svc QueryService) Query(ctx context.Context, query Query, listParams servi
 				}
 
 				for res := queryResult.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit, MergeOpOr)
 				}
 			}
 		}
@@ -184,13 +184,24 @@ func (svc QueryService) Query(ctx context.Context, query Query, listParams servi
 	}
 
 	for res := resultSet.List(); res != nil; res = res.Next() {
-		queryResults = append(queryResults, QueryResult{
-			ObjectType: res.ObjectType,
-			ObjectId:   res.ObjectId,
-			Relation:   res.Relation,
-			Warrant:    res.Warrant,
-			IsImplicit: res.IsImplicit,
-		})
+		var err error
+		addResult := true
+		if res.Policy != "" {
+			addResult, err = res.Policy.Eval(query.Context)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
+
+		if addResult {
+			queryResults = append(queryResults, QueryResult{
+				ObjectType: res.ObjectType,
+				ObjectId:   res.ObjectId,
+				Relation:   res.Relation,
+				Warrant:    res.Warrant,
+				IsImplicit: res.IsImplicit,
+			})
+		}
 	}
 
 	// handle sorting and pagination
@@ -358,26 +369,33 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 					}
 
 					if matchedWarrant.ObjectId == warrant.Wildcard {
-						expandedWildcardWarrants, err := svc.listWarrants(ctx, warrant.FilterParams{
-							ObjectType: matchedWarrant.ObjectType,
-						})
+						expandedObjects, err := svc.listObjectsByType(ctx, matchedWarrant.ObjectType)
 						if err != nil {
 							return nil, err
 						}
 
-						for _, w := range expandedWildcardWarrants {
-							if w.ObjectId != warrant.Wildcard {
-								resultSet.Add(w.ObjectType, w.ObjectId, relation, matchedWarrant, sub.IsImplicit || level > 0)
-							}
+						for _, obj := range expandedObjects {
+							resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
 						}
 					} else {
-						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, sub.IsImplicit || level > 0)
+						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
 					}
 				}
 			} else if query.SelectObjects.WhereSubject == nil ||
 				(matchedWarrant.Subject.ObjectType == query.SelectObjects.WhereSubject.Type &&
 					matchedWarrant.Subject.ObjectId == query.SelectObjects.WhereSubject.Id) {
-				resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, false)
+				if matchedWarrant.ObjectId == warrant.Wildcard {
+					expandedObjects, err := svc.listObjectsByType(ctx, matchedWarrant.ObjectType)
+					if err != nil {
+						return nil, err
+					}
+
+					for _, obj := range expandedObjects {
+						resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
+					}
+				} else {
+					resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
+				}
 			}
 		}
 
@@ -388,7 +406,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 			}
 
 			for res := implicitResultSet.List(); res != nil; res = res.Next() {
-				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
 			}
 		}
 
@@ -436,10 +454,10 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 				}
 
 				for sub := subset.List(); sub != nil; sub = sub.Next() {
-					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, sub.IsImplicit || level > 0)
+					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
 				}
 			} else if query.SelectSubjects.SubjectTypes[0] == matchedWarrant.Subject.ObjectType {
-				resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, relation, matchedWarrant, false)
+				resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
 			}
 		}
 
@@ -450,7 +468,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 			}
 
 			for res := implicitResultSet.List(); res != nil; res = res.Next() {
-				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
 			}
 		}
 
@@ -517,7 +535,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 
 				resultSet := NewResultSet()
 				for res := results.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
 				}
 
 				return resultSet, nil
@@ -538,24 +556,55 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 						continue
 					}
 
-					inheritedResults, err := svc.query(ctx, Query{
-						Expand: query.Expand,
-						SelectObjects: &SelectObjects{
-							ObjectTypes: query.SelectObjects.ObjectTypes,
-							WhereSubject: &Resource{
-								Type: indirectWarrant.ObjectType,
-								Id:   indirectWarrant.ObjectId,
-							},
-							Relations: []string{rule.WithRelation},
-						},
-						Context: query.Context,
-					}, 0)
-					if err != nil {
-						return nil, err
-					}
+					if indirectWarrant.ObjectId == warrant.Wildcard {
+						expandedObjects, err := svc.listObjectsByType(ctx, indirectWarrant.ObjectType)
+						if err != nil {
+							return nil, err
+						}
 
-					for res := inheritedResults.List(); res != nil; res = res.Next() {
-						resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+						for _, obj := range expandedObjects {
+							if obj.ObjectId != indirectWarrant.Subject.ObjectId {
+								inheritedResults, err := svc.query(ctx, Query{
+									Expand: query.Expand,
+									SelectObjects: &SelectObjects{
+										ObjectTypes: query.SelectObjects.ObjectTypes,
+										WhereSubject: &Resource{
+											Type: obj.ObjectType,
+											Id:   obj.ObjectId,
+										},
+										Relations: []string{rule.WithRelation},
+									},
+									Context: query.Context,
+								}, 0)
+								if err != nil {
+									return nil, err
+								}
+
+								for res := inheritedResults.List(); res != nil; res = res.Next() {
+									resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
+								}
+							}
+						}
+					} else {
+						inheritedResults, err := svc.query(ctx, Query{
+							Expand: query.Expand,
+							SelectObjects: &SelectObjects{
+								ObjectTypes: query.SelectObjects.ObjectTypes,
+								WhereSubject: &Resource{
+									Type: indirectWarrant.ObjectType,
+									Id:   indirectWarrant.ObjectId,
+								},
+								Relations: []string{rule.WithRelation},
+							},
+							Context: query.Context,
+						}, 0)
+						if err != nil {
+							return nil, err
+						}
+
+						for res := inheritedResults.List(); res != nil; res = res.Next() {
+							resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
+						}
 					}
 				}
 
@@ -578,7 +627,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 
 				resultSet := NewResultSet()
 				for res := results.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
 				}
 
 				return resultSet, nil
@@ -616,7 +665,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 					}
 
 					for res := subset.List(); res != nil; res = res.Next() {
-						resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.IsImplicit || level > 0)
+						resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, w.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
 					}
 				}
 
@@ -643,6 +692,30 @@ func (svc QueryService) listWarrants(ctx context.Context, filterParams warrant.F
 		}
 
 		result = append(result, warrantSpecs...)
+
+		if nextCursor == nil {
+			return result, nil
+		}
+
+		listParams.NextCursor = nextCursor
+	}
+}
+
+func (svc QueryService) listObjectsByType(ctx context.Context, objectType string) ([]object.ObjectSpec, error) {
+	var result []object.ObjectSpec
+	listParams := service.DefaultListParams(object.ObjectListParamParser{})
+	listParams.WithLimit(MaxEdges)
+	for {
+		objectSpecs, _, nextCursor, err := svc.objectSvc.List(
+			ctx,
+			&object.FilterOptions{ObjectType: objectType},
+			listParams,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, objectSpecs...)
 
 		if nextCursor == nil {
 			return result, nil

--- a/pkg/authz/query/service.go
+++ b/pkg/authz/query/service.go
@@ -114,7 +114,7 @@ func (svc QueryService) Query(ctx context.Context, query Query, listParams servi
 				}
 
 				for res := queryResult.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit, MergeOpOr)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit)
 				}
 			}
 		}
@@ -175,7 +175,7 @@ func (svc QueryService) Query(ctx context.Context, query Query, listParams servi
 				}
 
 				for res := queryResult.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit, MergeOpOr)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit)
 				}
 			}
 		}
@@ -375,10 +375,10 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 						}
 
 						for _, obj := range expandedObjects {
-							resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
+							resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
 						}
 					} else {
-						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
+						resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
 					}
 				}
 			} else if query.SelectObjects.WhereSubject == nil ||
@@ -391,10 +391,10 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 					}
 
 					for _, obj := range expandedObjects {
-						resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
+						resultSet.Add(obj.ObjectType, obj.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false)
 					}
 				} else {
-					resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
+					resultSet.Add(matchedWarrant.ObjectType, matchedWarrant.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false)
 				}
 			}
 		}
@@ -406,7 +406,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 			}
 
 			for res := implicitResultSet.List(); res != nil; res = res.Next() {
-				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
+				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0)
 			}
 		}
 
@@ -454,10 +454,10 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 				}
 
 				for sub := subset.List(); sub != nil; sub = sub.Next() {
-					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0, MergeOpOr)
+					resultSet.Add(sub.ObjectType, sub.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, sub.IsImplicit || level > 0)
 				}
 			} else if query.SelectSubjects.SubjectTypes[0] == matchedWarrant.Subject.ObjectType {
-				resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false, MergeOpOr)
+				resultSet.Add(matchedWarrant.Subject.ObjectType, matchedWarrant.Subject.ObjectId, relation, matchedWarrant, matchedWarrant.Policy, false)
 			}
 		}
 
@@ -468,7 +468,7 @@ func (svc QueryService) query(ctx context.Context, query Query, level int) (*Res
 			}
 
 			for res := implicitResultSet.List(); res != nil; res = res.Next() {
-				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
+				resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0)
 			}
 		}
 
@@ -535,7 +535,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 
 				resultSet := NewResultSet()
 				for res := results.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0)
 				}
 
 				return resultSet, nil
@@ -581,7 +581,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 								}
 
 								for res := inheritedResults.List(); res != nil; res = res.Next() {
-									resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
+									resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0)
 								}
 							}
 						}
@@ -603,7 +603,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 						}
 
 						for res := inheritedResults.List(); res != nil; res = res.Next() {
-							resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
+							resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, indirectWarrant.Policy.Or(res.Policy), res.IsImplicit || level > 0)
 						}
 					}
 				}
@@ -627,7 +627,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 
 				resultSet := NewResultSet()
 				for res := results.List(); res != nil; res = res.Next() {
-					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0, MergeOpOr)
+					resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, res.Policy, res.IsImplicit || level > 0)
 				}
 
 				return resultSet, nil
@@ -665,7 +665,7 @@ func (svc QueryService) queryRule(ctx context.Context, query Query, level int, r
 					}
 
 					for res := subset.List(); res != nil; res = res.Next() {
-						resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, w.Policy.Or(res.Policy), res.IsImplicit || level > 0, MergeOpOr)
+						resultSet.Add(res.ObjectType, res.ObjectId, relation, res.Warrant, w.Policy.Or(res.Policy), res.IsImplicit || level > 0)
 					}
 				}
 

--- a/pkg/authz/query/spec.go
+++ b/pkg/authz/query/spec.go
@@ -15,10 +15,12 @@
 package authz
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
-	baseWarrant "github.com/warrant-dev/warrant/pkg/authz/warrant"
+	"github.com/pkg/errors"
+	warrant "github.com/warrant-dev/warrant/pkg/authz/warrant"
 	"github.com/warrant-dev/warrant/pkg/service"
 )
 
@@ -26,11 +28,21 @@ type Query struct {
 	Expand         bool
 	SelectSubjects *SelectSubjects
 	SelectObjects  *SelectObjects
-	Context        baseWarrant.PolicyContext
-	rawString      string
+	Context        warrant.PolicyContext
 }
 
-func (q Query) String() string {
+func (q *Query) WithContext(contextString string) error {
+	var context warrant.PolicyContext
+	err := json.Unmarshal([]byte(contextString), &context)
+	if err != nil {
+		return errors.Wrap(err, "query: error parsing query context")
+	}
+
+	q.Context = context
+	return nil
+}
+
+func (q *Query) String() string {
 	var str string
 	if q.Expand {
 		str = "select"
@@ -95,12 +107,12 @@ type QueryHaving struct {
 }
 
 type QueryResult struct {
-	ObjectType string                  `json:"objectType"`
-	ObjectId   string                  `json:"objectId"`
-	Relation   string                  `json:"relation"`
-	Warrant    baseWarrant.WarrantSpec `json:"warrant"`
-	IsImplicit bool                    `json:"isImplicit"`
-	Meta       map[string]interface{}  `json:"meta,omitempty"`
+	ObjectType string                 `json:"objectType"`
+	ObjectId   string                 `json:"objectId"`
+	Relation   string                 `json:"relation"`
+	Warrant    warrant.WarrantSpec    `json:"warrant"`
+	IsImplicit bool                   `json:"isImplicit"`
+	Meta       map[string]interface{} `json:"meta,omitempty"`
 }
 
 type QueryResponseV1 struct {

--- a/tests/v2/query-policy.json
+++ b/tests/v2/query-policy.json
@@ -1,0 +1,1370 @@
+{
+    "ignoredFields": [
+        "createdAt"
+    ],
+    "tests": [
+        {
+            "name": "assignRoleAdminMemberOfAllRoles",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "*",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "*",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleAdminMemberOfPermissionManageRoles",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "manage-roles",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "manage-roles",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "admin"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleManagerMemberOfPermissionCreateItem",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "create-item",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "create-item",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleManagerMemberOfPermissionDeleteItem",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "delete-item",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "delete-item",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleManagerMemberOfRoleAccountant",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "accountant",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "accountant",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "manager"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleAccountantMemberOfPermissionViewBalanceSheet",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-balance-sheet",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "accountant"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-balance-sheet",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "accountant"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleAccountantMemberOfRoleReadOnly",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "accountant"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "accountant"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignRoleReadOnlyMemberOfPermissionViewItems",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-items",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "read-only"
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "permission",
+                    "objectId": "view-items",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "role",
+                        "objectId": "read-only"
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignUserJohnMemberOfRoleAdminOnTeam1And2",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "headers": {
+                    "Warrant-Token": "latest"
+                },
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "john"
+                    },
+                    "policy": "team in ['team-1', 'team-2']"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "john"
+                    },
+                    "policy": "team in ['team-1', 'team-2']"
+                }
+            }
+        },
+        {
+            "name": "assignUserJohnMemberOfRoleAdminOnTeam3",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "headers": {
+                    "Warrant-Token": "latest"
+                },
+                "body": {
+                    "objectType": "role",
+                    "objectId": "manager",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "john"
+                    },
+                    "policy": "team == 'team-3'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "manager",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "john"
+                    },
+                    "policy": "team == 'team-3'"
+                }
+            }
+        },
+        {
+            "name": "assignUserJaneMemberOfRoleAccountantOnTeam1And3",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "accountant",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "jane"
+                    },
+                    "policy": "team in ['team-1', 'team-3']"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "accountant",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "jane"
+                    },
+                    "policy": "team in ['team-1', 'team-3']"
+                }
+            }
+        },
+        {
+            "name": "assignUserJaneMemberOfRoleReadOnlyOnTeam2",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "jane"
+                    },
+                    "policy": "team == 'team-2'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "jane"
+                    },
+                    "policy": "team == 'team-2'"
+                }
+            }
+        },
+        {
+            "name": "assignUserJamesMemberOfRoleAdminOnTeam1",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-1'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "admin",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-1'"
+                }
+            }
+        },
+        {
+            "name": "assignUserJamesMemberOfRoleManagerOnTeam2",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "manager",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-2'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "manager",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-2'"
+                }
+            }
+        },
+        {
+            "name": "assignUserJamesMemberOfRoleReadOnlyOnTeam3",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-3'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "role",
+                    "objectId": "read-only",
+                    "relation": "member",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "james"
+                    },
+                    "policy": "team == 'team-3'"
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJohnIsMemberInTeam1",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:john%20is%20member&context=%7B%22team%22%3A%22team-1%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "create-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "create-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "delete-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "delete-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "manage-roles",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "manage-roles",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "admin"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJohnIsMemberInTeam2",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:john%20is%20member&context=%7B%22team%22%3A%22team-2%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "create-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "create-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "delete-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "delete-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "manage-roles",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "manage-roles",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "admin"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJohnIsMemberInTeam3",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:john%20is%20member&context=%7B%22team%22%3A%22team-3%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "create-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "create-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "delete-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "delete-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJaneIsMemberInTeam1",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:jane%20is%20member&context=%7B%22team%22%3A%22team-1%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJaneIsMemberInTeam2",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:jane%20is%20member&context=%7B%22team%22%3A%22team-2%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJaneIsMemberInTeam3",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:jane%20is%20member&context=%7B%22team%22%3A%22team-3%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJamesIsMemberInTeam1",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:james%20is%20member&context=%7B%22team%22%3A%22team-1%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "create-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "create-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "delete-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "delete-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "manage-roles",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "manage-roles",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "admin"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJamesIsMemberInTeam2",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:james%20is%20member&context=%7B%22team%22%3A%22team-2%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "create-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "create-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "delete-item",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "delete-item",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "manager"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-balance-sheet",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-balance-sheet",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "accountant"
+                                }
+                            },
+                            "isImplicit": true
+                        },
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectPermissionsWhereUserJamesIsMemberInTeam3",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20permission%20where%20user:james%20is%20member&context=%7B%22team%22%3A%22team-3%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "permission",
+                            "objectId": "view-items",
+                            "relation": "member",
+                            "warrant": {
+                                "objectType": "permission",
+                                "objectId": "view-items",
+                                "relation": "member",
+                                "subject": {
+                                    "objectType": "role",
+                                    "objectId": "read-only"
+                                }
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "deleteUserJohn",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/john"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUserJane",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/jane"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUserJames",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/james"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleAdmin",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/admin"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleManager",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/manager"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleAccountant",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/accountant"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteRoleReadOnly",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/role/read-only"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionManageRoles",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/manage-roles"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionCreateItem",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/create-item"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionDeleteItem",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/delete-item"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionViewItems",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/view-items"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deletePermissionViewBalanceSheet",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/permission/view-balance-sheet"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "createDocumentObjectType",
+            "request": {
+                "method": "POST",
+                "url": "/v2/object-types",
+                "body": {
+                    "type": "document",
+                    "relations": {
+                        "owner": {},
+                        "editor": {
+                            "inheritIf": "owner"
+                        },
+                        "viewer": {
+                            "inheritIf": "editor"
+                        },
+                        "editor-viewer": {
+                            "inheritIf": "allOf",
+                            "rules": [
+                                {
+                                    "inheritIf": "editor"
+                                },
+                                {
+                                    "inheritIf": "viewer"
+                                }
+                            ]
+                        }
+                    }
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "document",
+                    "relations": {
+                        "owner": {},
+                        "editor": {
+                            "inheritIf": "owner"
+                        },
+                        "viewer": {
+                            "inheritIf": "editor"
+                        },
+                        "editor-viewer": {
+                            "inheritIf": "allOf",
+                            "rules": [
+                                {
+                                    "inheritIf": "editor"
+                                },
+                                {
+                                    "inheritIf": "viewer"
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "name": "assignUserU1OwnerOfDocumentD1InTeamT1",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "document",
+                    "objectId": "D1",
+                    "relation": "owner",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "U1"
+                    },
+                    "policy": "team == 'T1'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "document",
+                    "objectId": "D1",
+                    "relation": "owner",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "U1"
+                    },
+                    "policy": "team == 'T1'"
+                }
+            }
+        },
+        {
+            "name": "assignUserU2ViewerOfDocumentD1InTeamT2",
+            "request": {
+                "method": "POST",
+                "url": "/v2/warrants",
+                "body": {
+                    "objectType": "document",
+                    "objectId": "D1",
+                    "relation": "viewer",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "U2"
+                    },
+                    "policy": "team == 'T2'"
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "objectType": "document",
+                    "objectId": "D1",
+                    "relation": "viewer",
+                    "subject": {
+                        "objectType": "user",
+                        "objectId": "U2"
+                    },
+                    "policy": "team == 'T2'"
+                }
+            }
+        },
+        {
+            "name": "selectDocumentsWhereUserU1IsEditorViewerInTeamT1",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20document%20where%20user:U1%20is%20editor-viewer&context=%7B%22team%22%3A%22T1%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "document",
+                            "objectId": "D1",
+                            "relation": "editor-viewer",
+                            "warrant": {
+                                "objectType": "document",
+                                "objectId": "D1",
+                                "relation": "owner",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "U1"
+                                },
+                                "policy": "team == 'T1'"
+                            },
+                            "isImplicit": true
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "selectDocumentsWhereUserU1IsEditorViewerInTeamT2",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20document%20where%20user:U1%20is%20editor-viewer&context=%7B%22team%22%3A%22T2%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": []
+                }
+            }
+        },
+        {
+            "name": "selectDocumentsWhereUserU2IsEditorViewerInTeamT1",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20document%20where%20user:U2%20is%20editor-viewer&context=%7B%22team%22%3A%22T1%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": []
+                }
+            }
+        },
+        {
+            "name": "selectDocumentsWhereUserU2IsViewerInTeamT2",
+            "request": {
+                "method": "GET",
+                "url": "/v2/query?q=select%20document%20where%20user:U2%20is%20viewer&context=%7B%22team%22%3A%22T2%22%7D"
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "results": [
+                        {
+                            "objectType": "document",
+                            "objectId": "D1",
+                            "relation": "viewer",
+                            "warrant": {
+                                "objectType": "document",
+                                "objectId": "D1",
+                                "relation": "viewer",
+                                "subject": {
+                                    "objectType": "user",
+                                    "objectId": "U2"
+                                },
+                                "policy": "team == 'T2'"
+                            },
+                            "isImplicit": false
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "deleteDocumentD1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/document/D1"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUser1",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/U1"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteUser2",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/objects/user/U2"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        },
+        {
+            "name": "deleteObjectTypeDocument",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/object-types/document"
+            },
+            "expectedResponse": {
+                "statusCode": 200
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Describe your changes
This PR adds policy support to the query endpoint. The endpoint now accepts an optional `context` parameter which can contain a URL encoded JSON object containing various context to respect during the evaluation of the query.

## Issue number and link (if applicable)
Closes #314 