### PR TITLE
Allow creation of object-types with an empty relations block

### DIFF
--- a/pkg/authz/objecttype/spec.go
+++ b/pkg/authz/objecttype/spec.go
@@ -44,7 +44,7 @@ type ObjectTypeSpec struct {
 type CreateObjectTypeSpec struct {
 	Type      string                  `json:"type"             validate:"required,valid_object_type"`
 	Source    *Source                 `json:"source,omitempty"`
-	Relations map[string]RelationRule `json:"relations"        validate:"required,min=1,dive"` // NOTE: map key = name of relation
+	Relations map[string]RelationRule `json:"relations"        validate:"required,dive"` // NOTE: map key = name of relation
 }
 
 func (spec CreateObjectTypeSpec) ToObjectType() (*ObjectType, error) {

--- a/tests/v1/object-types-crud.json
+++ b/tests/v1/object-types-crud.json
@@ -4,7 +4,7 @@
     ],
     "tests": [
         {
-            "name": "failToCreateObjectWithoutRelations",
+            "name": "failToCreateObjectTypeWithoutRelations",
             "request": {
                 "method": "POST",
                 "url": "/v1/object-types",
@@ -19,6 +19,34 @@
                     "message": "Missing required parameter relations",
                     "parameter": "relations"
                 }
+            }
+        },
+        {
+            "name": "createObjectTypeWithEmptyRelations",
+            "request": {
+                "method": "POST",
+                "url": "/v1/object-types",
+                "body": {
+                    "type": "A",
+                    "relations": {}
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "A",
+                    "relations": {}
+                }
+            }
+        },
+        {
+            "name": "deleteObjectTypeWithEmptyRelations",
+            "request": {
+                "method": "DELETE",
+                "url": "/v1/object-types/A"
+            },
+            "expectedResponse": {
+                "statusCode": 200
             }
         },
         {

--- a/tests/v2/object-types-crud.json
+++ b/tests/v2/object-types-crud.json
@@ -4,7 +4,7 @@
     ],
     "tests": [
         {
-            "name": "failToCreateObjectWithoutRelations",
+            "name": "failToCreateObjectTypeWithoutRelations",
             "request": {
                 "method": "POST",
                 "url": "/v2/object-types",
@@ -19,6 +19,34 @@
                     "message": "Missing required parameter relations",
                     "parameter": "relations"
                 }
+            }
+        },
+        {
+            "name": "createObjectTypeWithEmptyRelations",
+            "request": {
+                "method": "POST",
+                "url": "/v2/object-types",
+                "body": {
+                    "type": "A",
+                    "relations": {}
+                }
+            },
+            "expectedResponse": {
+                "statusCode": 200,
+                "body": {
+                    "type": "A",
+                    "relations": {}
+                }
+            }
+        },
+        {
+            "name": "deleteObjectTypeWithEmptyRelations",
+            "request": {
+                "method": "DELETE",
+                "url": "/v2/object-types/A"
+            },
+            "expectedResponse": {
+                "statusCode": 200
             }
         },
         {


### PR DESCRIPTION
## Describe your changes
Allows creation of object-types with an empty relations block. For example:
```json
{
   "type": "user",
   "relations": {}
}
```

## Issue number and link (if applicable)
Closes #317