### PR TITLE
Add word boundary at beginning and end of all query language keywords in query lexer

### DIFF
--- a/pkg/authz/query/parser.go
+++ b/pkg/authz/query/parser.go
@@ -46,12 +46,12 @@ type ast struct {
 }
 
 var participleLexer = lexer.MustSimple([]lexer.SimpleRule{
-	{Name: "Select", Pattern: `(?i)select`},
-	{Name: "Explicit", Pattern: `(?i)explicit`},
-	{Name: "Where", Pattern: `(?i)where`},
-	{Name: "Is", Pattern: `(?i)is`},
-	{Name: "For", Pattern: `(?i)for`},
-	{Name: "OfType", Pattern: `(?i)of type`},
+	{Name: "Select", Pattern: `(?i)\bselect\b`},
+	{Name: "Explicit", Pattern: `(?i)\bexplicit\b`},
+	{Name: "Where", Pattern: `(?i)\bwhere\b`},
+	{Name: "Is", Pattern: `(?i)\bis\b`},
+	{Name: "For", Pattern: `(?i)\bfor\b`},
+	{Name: "OfType", Pattern: `(?i)\bof type\b`},
 	{Name: "Resource", Pattern: `[a-zA-Z0-9_\-]+:[a-zA-Z0-9_\-\.@\|:]+`},
 	{Name: "TypeOrRelation", Pattern: `[a-zA-Z0-9_\-]+`},
 	{Name: "Wildcard", Pattern: `\*`},


### PR DESCRIPTION
## Describe your changes
Add word boundary at beginning and end of all query language keywords in query lexer. This prevents the lexer from incorrectly matching user-defined object-types and resources as query language keywords which can result in the query API incorrectly reporting syntax errors.

## Issue number and link (if applicable)
Closes #330 